### PR TITLE
Fix newlib tests

### DIFF
--- a/newlib/testsuite/newlib.locale/UTF-8.exp
+++ b/newlib/testsuite/newlib.locale/UTF-8.exp
@@ -6,6 +6,19 @@
 
 load_lib checkoutput.exp
 
+# Don't run this test if newlib's build does not
+# support multibyte encodings.
+set newlib_header_name "$objdir/targ-include/newlib.h"
+if [file exists $newlib_header_name] {
+    set newlib_header_fid [open $newlib_header_name r]
+    set newlib_header_text [read $newlib_header_fid]
+    close $newlib_header_fid
+    if {![regexp "#define _MB_CAPABLE" $newlib_header_text] || \
+            [regexp "#define _MB_LEN_MAX 1" $newlib_header_text]} {
+        return
+    }
+}
+
 set expected_output {
 "Set C-UTF-8 locale."
 "* U-00000000"

--- a/newlib/testsuite/newlib.stdlib/atexit.exp
+++ b/newlib/testsuite/newlib.stdlib/atexit.exp
@@ -6,6 +6,10 @@
 
 load_lib checkoutput.exp
 
+if { [board_info [target_info name] protocol] == "gdb_comm" } {
+    return
+}
+
 set output {
 "a0cba"
 }


### PR DESCRIPTION
I've fixed these tests especially for ARC:

1. `newlib.locale/UTF-8.exp` (https://github.com/foss-for-synopsys-dwc-arc-processors/newlib/commit/b3fc70d32d5d2bd3a570706c6a17d17e5331886e)
2. `newlib.stdlib/atexit.exp` (https://github.com/foss-for-synopsys-dwc-arc-processors/newlib/commit/75c0451795cfd1fce376154dfb06746e75af9cbb)