### PR TITLE
Fix UTF-8.exp and atexit.exp tests

### DIFF
--- a/newlib/ChangeLog.ARC
+++ b/newlib/ChangeLog.ARC
@@ -1,3 +1,10 @@
+2015-05-19 Yuriy Kolerov <yuriy.kolerov@synopsys.com>
+
+	* newlib/testsuite/newlib.stdlib/atexit.exp: Don't run
+	      this test for boards with GDB
+	* newlib/testsuite/newlib.locale/UTF-8.exp: Don't run this
+	      test if newlib is not built with multibyte support
+
 2015-12-17 Claudiu Zissulescu <claziss@synopsys.com>
 	   Cupertino Miranda <cupertino.miranda@synopsys.com>
 

--- a/newlib/testsuite/newlib.locale/UTF-8.exp
+++ b/newlib/testsuite/newlib.locale/UTF-8.exp
@@ -6,6 +6,19 @@
 
 load_lib checkoutput.exp
 
+# Don't run this test if newlib's build does not
+# support multibyte encodings.
+set newlib_header_name "$objdir/targ-include/newlib.h"
+if [file exists $newlib_header_name] {
+    set newlib_header_fid [open $newlib_header_name r]
+    set newlib_header_text [read $newlib_header_fid]
+    close $newlib_header_fid
+    if {![regexp "#define _MB_CAPABLE" $newlib_header_text] || \
+            [regexp "#define _MB_LEN_MAX 1" $newlib_header_text]} {
+        return
+    }
+}
+
 set expected_output {
 "Set C-UTF-8 locale."
 "* U-00000000"

--- a/newlib/testsuite/newlib.stdlib/atexit.exp
+++ b/newlib/testsuite/newlib.stdlib/atexit.exp
@@ -6,6 +6,10 @@
 
 load_lib checkoutput.exp
 
+if { [board_info [target_info name] protocol] == "gdb_comm" } {
+    return
+}
+
 set output {
 "a0cba"
 }


### PR DESCRIPTION
Don't run atexit.exp test for boards with GDB. Some ARC boards with GDB break on exit() and return immediately. Thus it's impossible to pass atexit.exp test for these boards.

Don't run UTF-8.exp test if newlib is not built with multibyte support.