### PR TITLE
Add implementaions for system calls stat and times for ARC

### DIFF
--- a/newlib/ChangeLog.ARC
+++ b/newlib/ChangeLog.ARC
@@ -1,3 +1,8 @@
+2015-05-28  Yuriy Kolerov  <yuriy.kolerov@synopsys.com>
+
+	* newlib/libc/sys/arc/syscalls.c: Add implementations
+	for ARC system calls stat and times.
+
 2015-05-19 Yuriy Kolerov <yuriy.kolerov@synopsys.com>
 
 	* newlib/testsuite/newlib.stdlib/atexit.exp: Don't run

--- a/newlib/ChangeLog.ARC
+++ b/newlib/ChangeLog.ARC
@@ -1,3 +1,7 @@
+2015-05-29  Yuriy Kolerov  <yuriy.kolerov@synopsys.com>
+
+	* newlib/libc/sys/arc/syscalls.c: Fix formatting.
+
 2015-05-28  Yuriy Kolerov  <yuriy.kolerov@synopsys.com>
 
 	* newlib/libc/sys/arc/syscalls.c: Add implementations

--- a/newlib/libc/sys/arc/syscalls.c
+++ b/newlib/libc/sys/arc/syscalls.c
@@ -9,14 +9,14 @@
 #include <reent.h>
 #include <unistd.h>
 
-_syscall3 (_ssize_t,read, int,fd, void *,buf, size_t,nbytes)
+_syscall3 (_ssize_t, read, int, fd, void *, buf, size_t, nbytes)
 
-_syscall3 (_ssize_t,write, int,fd, const void *,buf, size_t,nbytes)
+_syscall3 (_ssize_t, write, int, fd, const void *, buf, size_t, nbytes)
 
-/* FIXME: The prototype in <fcntl.h> for open() uses ...,
+/* FIXME: The prototype in <fcntl.h> for open () uses...,
    but reent.h uses int.  */
 
-_syscall3 (int,open, const char *,buf, int,flags, int,mode)
+_syscall3 (int, open, const char *, buf, int, flags, int, mode)
 #if 0
   /* Could put this into a variant of _syscall3:  */
   int mode;
@@ -27,19 +27,19 @@ _syscall3 (int,open, const char *,buf, int,flags, int,mode)
   va_end (ap);
 #endif
 
-_syscall1 (int,close, int,fd)
+_syscall1 (int, close, int, fd)
 
-_syscall3 (off_t,lseek, int,fd, off_t,offset, int,whence)
+_syscall3 (off_t, lseek, int, fd, off_t, offset, int, whence)
 
-_syscall2 (int,fstat, int,file, struct stat *,st)
+_syscall2 (int, fstat, int, file, struct stat *, st)
 
-_syscall2 (int,gettimeofday, struct timeval *,tv, void *,tz)
+_syscall2 (int, gettimeofday, struct timeval *, tv, void *, tz)
 
-_syscall1 (void,exit, int,ret)
+_syscall1 (void, exit, int, ret)
 
-_syscall1 (_CLOCK_T_,times, struct tms *,buf)
+_syscall1 (_CLOCK_T_, times, struct tms *, buf)
 
-_syscall2 (int,stat, const char *,file, struct stat *,st)
+_syscall2 (int, stat, const char *, file, struct stat *, st)
 
 time_t
 _time (time_t *timer)

--- a/newlib/libc/sys/arc/syscalls.c
+++ b/newlib/libc/sys/arc/syscalls.c
@@ -1,11 +1,13 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <sys/syscall.h>
+#include <sys/times.h>
 #include <_ansi.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <stdarg.h>
 #include <reent.h>
+#include <unistd.h>
 
 _syscall3 (_ssize_t,read, int,fd, void *,buf, size_t,nbytes)
 
@@ -34,6 +36,10 @@ _syscall2 (int,fstat, int,file, struct stat *,st)
 _syscall2 (int,gettimeofday, struct timeval *,tv, void *,tz)
 
 _syscall1 (void,exit, int,ret)
+
+_syscall1 (_CLOCK_T_,times, struct tms *,buf)
+
+_syscall2 (int,stat, const char *,file, struct stat *,st)
 
 time_t
 _time (time_t *timer)


### PR DESCRIPTION
Macros _syscallX are used to implement these system calls.
So it means that in fact functions _stat_r and _times_r are
implemented.

Signed-off-by: Yuriy Kolerov <yuriy.kolerov@synopsys.com>