### PR TITLE
Fix memcmp for big endian targets

### DIFF
--- a/newlib/ChangeLog.ARC
+++ b/newlib/ChangeLog.ARC
@@ -1,3 +1,9 @@
+2015-06-03  Yuriy Kolerov  <yuriy.kolerov@synopsys.com>
+
+	* newlib/libc/machine/arc/memcmp-601.S: Turn of
+	an optimization for aligned case for big endian
+	targets until an algorithm is fixed.
+
 2015-05-29  Yuriy Kolerov  <yuriy.kolerov@synopsys.com>
 
 	* newlib/libc/sys/arc/syscalls.c: Fix formatting.

--- a/newlib/libc/machine/arc/memcmp-601.S
+++ b/newlib/libc/machine/arc/memcmp-601.S
@@ -14,7 +14,17 @@ ENTRY(memcmp)
 	tst	r12,3
 	breq	r2,0,.Lnil
 	add_s	r3,r0,r2
+	
+/* This algorithm for big endian targets sometimes works incorrectly
+   when sources are aligned. To be precise the last step is omitted.
+   Just use a simple bytewise variant until the algorithm is reviewed
+   and fixed.  */
+   
+#ifdef __LITTLE_ENDIAN__
 	bne_s	.Lbytewise
+#else /* BIG ENDIAN */
+	b_s	.Lbytewise
+#endif /* ENDIAN */
 	sub	r6,r3,8
 	ld	r4,[r0,0]
 	ld	r5,[r1,0]


### PR DESCRIPTION
The algorithm works incorrectly when sources are aligned. It's necessary to review and fix it later but now just turn off an optimization.

Right now I'm stuck on this heavily optimized and undocumented thing.

STAR: 9000906645

Signed-off-by: Yuriy Kolerov <yuriy.kolerov@synopsys.com>