### PR TITLE
[ARC] [libgloss] Fix build from external path

### DIFF
--- a/libgloss/arc/configure
+++ b/libgloss/arc/configure
@@ -2570,7 +2570,7 @@ test "${CCASFLAGS+set}" = set || CCASFLAGS=$CFLAGS
 
 
 
-host_makefile_frag=${srcdir}/../config/default.mh
+host_makefile_frag=`cd ${srcdir}/../config;pwd`/default.mh
 
 host_makefile_frag_path=$host_makefile_frag
 

--- a/libgloss/arc/configure.in
+++ b/libgloss/arc/configure.in
@@ -39,7 +39,7 @@ AC_SUBST(LD)
 AC_PROG_RANLIB
 LIB_AM_PROG_AS
 
-host_makefile_frag=${srcdir}/../config/default.mh
+host_makefile_frag=`cd ${srcdir}/../config;pwd`/default.mh
 
 dnl We have to assign the same value to other variables because autoconf
 dnl doesn't provide a mechanism to substitute a replacement keyword with


### PR DESCRIPTION
host_makefile_frag_path dependency can not be used from
hl folder, because this path is relative to libgloss/arc.

This fix makes host_makefile_frag_path absolute (same as for ARM).