### PR TITLE
Bruno strlen implementation jira p10019563 45850

### DIFF
--- a/newlib/libc/machine/arc64/Makefile.am
+++ b/newlib/libc/machine/arc64/Makefile.am
@@ -13,6 +13,7 @@ lib_a_SOURCES =                 \
         memcpy-stub.c           \
         memset.S                \
         memset-stub.c           \
+        strlen.S                \
         setjmp.S
 
 lib_a_CCASFLAGS=$(AM_CCASFLAGS)

--- a/newlib/libc/machine/arc64/Makefile.in
+++ b/newlib/libc/machine/arc64/Makefile.in
@@ -121,7 +121,7 @@ lib_a_LIBADD =
 am_lib_a_OBJECTS = lib_a-memcmp.$(OBJEXT) lib_a-memcmp-stub.$(OBJEXT) \
 	lib_a-memcpy.$(OBJEXT) lib_a-memcpy-stub.$(OBJEXT) \
 	lib_a-memset.$(OBJEXT) lib_a-memset-stub.$(OBJEXT) \
-	lib_a-setjmp.$(OBJEXT)
+	lib_a-strlen.$(OBJEXT) lib_a-setjmp.$(OBJEXT)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -346,6 +346,7 @@ lib_a_SOURCES = \
         memcpy-stub.c           \
         memset.S                \
         memset-stub.c           \
+        strlen.S                \
         setjmp.S
 
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
@@ -424,6 +425,12 @@ lib_a-memset.o: memset.S
 
 lib_a-memset.obj: memset.S
 	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-memset.obj `if test -f 'memset.S'; then $(CYGPATH_W) 'memset.S'; else $(CYGPATH_W) '$(srcdir)/memset.S'; fi`
+
+lib_a-strlen.o: strlen.S
+	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strlen.o `test -f 'strlen.S' || echo '$(srcdir)/'`strlen.S
+
+lib_a-strlen.obj: strlen.S
+	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strlen.obj `if test -f 'strlen.S'; then $(CYGPATH_W) 'strlen.S'; else $(CYGPATH_W) '$(srcdir)/strlen.S'; fi`
 
 lib_a-setjmp.o: setjmp.S
 	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-setjmp.o `test -f 'setjmp.S' || echo '$(srcdir)/'`setjmp.S

--- a/newlib/libc/machine/arc64/strlen.S
+++ b/newlib/libc/machine/arc64/strlen.S
@@ -30,125 +30,129 @@
 
 #include <sys/asm.h>
 
-; Brief:
-; This code "fixes" alignment of the input pointer and performs 8 byte searches
-; in 32 byte chunks.
-; It is therefore optimized for big strings, presenting some overhead for
-; smaller strings
+; Code Brief:
+; Correct input pointer alignment and perform four 8 byte block search
+; This code is optimized for big strings, but also performs well for small
+; ones
 ;
-; R0 const char* ptr
+; R0 const char* ptr (string to measure)
 ; ret (R0):
-;		- String size
+;		- unsigned (string size)
+;
 
 #if defined (__ARC64_ARCH64__)
 
 ENTRY (strlen)
 
 ; If address is 4 byte aligned, we can just directly read 4 bytes
-	bmsk.f	r3,		r0,		1
-	beq.d			@.L_start_4byte_search
-	MOVP	r13,	r0	; Store r0 for size calculation
+bmsk.f	r3,		r0,		1
+beq.d			@.L_4B_step
 
-	subl	r3,		r3,		1		; [0]
-	asl		r3,		r3,		2		; [1]
+; Store r0 for size calculation when returning
+MOVP	r13,	r0
 
-; Jump depending on the alignment
-	bi	    [r3]
+subl	r3,		r3,		1		; [0]
+asl		r3,		r3,		2		; [1]
+
+; Jump depending on the alignment.
+bi	    [r3]
 ; Read 3 bytes
-	ldb.ab	r10,	[r13,	+1]
-	cmp		r10,	0
-	beq 			@.L_return_ptr
-	nop
+ldb.ab	r10,	[r13,	+1]
+cmp		r10,	0
+beq 			@.L_return_size
+nop
 ; Read 2 bytes
-	ldb.ab	r10,	[r13,	+1]
-	cmp		r10,	0
-	beq				@.L_return_ptr
-	nop
+ldb.ab	r10,	[r13,	+1]
+cmp		r10,	0
+beq				@.L_return_size
+nop
 ; Read 1 byte
-	ldb.ab	r10,	[r13,	+1]
-	cmp		r10,	0
-	beq				@.L_return_ptr
-	nop
+ldb.ab	r10,	[r13,	+1]
+cmp		r10,	0
+beq				@.L_return_size
 
-; r13 is now either 4 or 8 byte aligned
-.L_start_4byte_search:
+; Last nop can be removed [2]
+
+; By this point, r13 is either 4 or 8 byte aligned
+.L_4B_step:
 
 ; If aligned to 8 bytes, just jump ahead
-	andl.f	0,		r13,	0b111
-	beq.d	@1f
-	xorl	r6,		r6,		r6	; reset mask showing NULL byte location
+andl.f	0,		r13,	0b111
+beq.d	@.L_start_4_8B_search
+; Always reset bit mask that will encode NULL byte location
+xorl	r6,		r6,		r6
 
-	ld.ab	r10,	[r13,	+4]
-	sub		r8,		r10,	NULL_32DT_1
-	bic		r8,		r8,		r10
-	tst		r8,		NULL_32DT_2
-	bne.d		@.L_reread_last_4bytes
-	xorl	r9,		r9,		r9
+ld.ab	r10,	[r13,	+4]
+sub		r11,	r10,	NULL_32DT_1
+bic		r11,	r11,	r10
+tst		r11,	NULL_32DT_2
+bne		@.L_reread_last_4bytes
 
-1:
-; Setup byte detector (more information bellow) [2]
-	movhl	r8,		NULL_32DT_1
-	orl		r8,		r8,		NULL_32DT_1
+.L_start_4_8B_search:
+; Setup byte detector (more information bellow) [3] [5]
+movhl	r8,		NULL_32DT_1
+movhl	r9,		NULL_32DT_2
 
-	movhl	r9,		NULL_32DT_2
-	orl		r9,		r9,		NULL_32DT_2
+orl		r8,		r8,		NULL_32DT_1
+orl		r9,		r9,		NULL_32DT_2
 
-	ldl.ab	  r2,	[r13, +8]
-.L_search_32bytes:
-	ldl.ab	  r3,	[r13, +8]
-	ldl.ab	  r4,	[r13, +8]
-	ldl.ab	  r5,	[r13, +8]
+ldl.ab	r2,		[r13,	+8]
+.L_4_8B_search:
+		ldl.ab	r3,		[r13,	+8]
+		ldl.ab	r4,		[r13,	+8]
+		ldl.ab	r5,		[r13,	+8]
 
-; If there is a 0 in any of the read 32 bytes, its location is encoded
-; in r6 as a bit mask
-; This bitmask can be used to calculate the appropriate regression in the pointer [3]
-	subl	r10,	r2,		r8
-	subl	r11,	r3,		r8
-	subl	r12,	r4,		r8
-	subl	r7,		r5,		r8
+	; NULL byte position is detected and encoded in r6 [4] [5]
+		subl	r10,	r2,		r8
+		subl	r11,	r3,		r8
+		subl	r12,	r4,		r8
+		subl	r7,		r5,		r8
 
-	bicl	r10,	r10,	r2
-	bicl	r11,	r11,	r3
-	bicl	r12,	r12,	r4
-	bicl	r7,		r7,		r5
+		bicl	r10,	r10,	r2
+		bicl	r11,	r11,	r3
+		bicl	r12,	r12,	r4
+		bicl	r7,		r7,		r5
 
-	tstl	r10,	r9
-	xor.ne	r6,		r6,		0b10000
+		tstl	r10,	r9
+		xor.ne	r6,		r6,		0b10000
 
-	tstl	r11,	r9
-	xor.ne	r6,		r6,		0b01000
+		tstl	r11,	r9
+		xor.ne	r6,		r6,		0b01000
 
-	tstl	r12,	r9
-	xor.ne	r6,		r6,		0b00100
+		tstl	r12,	r9
+		xor.ne	r6,		r6,		0b00100
 
-	tstl	r7,		r9
-	xor.ne	r6,		r6,		0b00010
+		tstl	r7,		r9
+		xor.ne	r6,		r6,		0b00010
 
-	breq.d	r6,		0,		@.L_search_32bytes
-	ldl.ab	r2,		[r13,	+8]
+		breq.d	r6,		0,		@.L_4_8B_search
+		ldl.ab	r2,		[r13,	+8]
 
 ; Back track only what is required [4]
 fls		r6,		r6
 asl		r6,		r6,		3
 subl	r13,	r13,	r6
 
-; Compensate writeback
+; Compensate writeback in the loop break
+; Should be 8 byte compensation, but if we only compensate 4 bytes we can
+; fallthrough to 4 byte reread
 subl	r13,	r13,	4
+
 .L_reread_last_4bytes:
 subl	r13,	r13,	4
 
-;; 1 byte search until NULL byte is found
+; Perform 1 byte search until NULL byte is found
 ldb		r10,	[r13]
 .L_search_next_1byte_chunk:
-	cmp		r10,	0
-	bne.d	@.L_search_next_1byte_chunk
-	ldb.aw	r10,	[r13, +1]
+		cmp		r10,	0
+		bne.d	@.L_search_next_1byte_chunk
+		ldb.aw	r10,	[r13, +1]
 
-; NULL byte was found in r0 - 1
-.L_return_ptr:
-	subl	r0,		r13,		r0
-	j_s.d	[blink]
-	subl	r0,		r0,		1
+; NULL byte was found in r13 - 1
+.L_return_size:
+subl	r0,		r13,		r0
+j_s.d	[blink]
+subl	r0,		r0,		1
 
 ;; The first step in this code is to "fix" the address alignment
 ;
@@ -168,31 +172,45 @@ ldb		r10,	[r13]
 ;   11b (3) |        1        |        2       |   8
 ;
 ; Removing 1 from b1b0 [0] gives us the "branch index".
-; Now to get the appropriate jump size (how many instructions there are per branch)
-; we can just multiply by 4 [1]
+; Now to get the appropriate jump size (how many instructions there are per
+; branch) we can just multiply by 4 [1]
+;
+; The last "branch" will never be jumped. If it was, we wouldnt be reading any
+; byte and therefore not aligning (the address would have already be aligned to
+; start with). This means we can safely remove the nop from it [2].
+; The nops could also be removed entirely by having r3 be multiples of 3*8
+; but the extra operation isnt worth it
 ;
 ;; This code uses a common technique for NULL byte detection inside a word.
 ;; Details on this technique can be found in:
 ;; (https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord)
 ;
-; In sum, this technique allows for detecting a NULL byte inside any given amount of
-; bits by performing the following operation
+; In sum, this technique allows for detecting a NULL byte inside any given 
+; amount of bits by performing the following operation
 ; 		DETECTNULL(X) (((X) - 0x01010101) & ~(X) & 0x80808080)
 ;
-; The code above implements this by setting r8 to 0x01010101 and r9 to 0x80808080
-; This operation differs slightly between 64 bit and 32 bit analizysis, as LIMM are 32
-; bit only, we need to perform MOVHL and ORL [2] operations to have the appropriate 64bit
-; values in place
+; The code above implements this by setting r8 to 0x01010101 and r9 to
+; 0x80808080
+; This operation differs slightly between 64 bit and 32 bit analysis.
+; As LIMM are 32 bit only, we need to perform MOVHL and ORL [3] operations to
+; have the appropriate 64 bit values in place
 ;
 ;; The major optimization in this code is to perform several 8 load byte loads
-;; in a row and using the previously mentioned NULL byte detection method to find
-;; the end of the string
+;; in a row and using the previously mentioned NULL byte detection method to
+;; find the end of the string
 ;
-; To achieve this, finding a NULL byte sets a bitmask that [3], when passed via
-; the "find last set" instruction returns the amount of 8 byte chunks to backtrack
-; We can then simply multiply by 8 and remove that value from the pointer
+; To achieve this, finding a NULL byte sets a bitmask that [4], when passed via
+; the "find last set" instruction returns the amount of 8 byte chunks to
+; backtrack. We can then simply multiply by 8 and remove that value from the
+; pointer to make it point to the 8 byte chunk containing the NULL byte.
+; We can then perform a simple byte search to find it.
+; One possible optimization is to not perform a final 1 byte search, but use
+; the already loaded registers to, depending on endianness, find the position
+; of the NULL byte and appropriately adjust the pointer for size calculation
 ;
-;
+; The order the NULL byte detection operations are performed in isnt random [5]
+; They are ordered in order to reduce register dependency and allow the CPU to
+; run them in parallel
 ;
 
 ENDFUNC (strlen)

--- a/newlib/libc/machine/arc64/strlen.S
+++ b/newlib/libc/machine/arc64/strlen.S
@@ -54,7 +54,7 @@ MOVP	r13,	r0
 subl	r3,		r3,		1		; [0]
 asl		r3,		r3,		2		; [1]
 
-; Jump depending on the alignment.
+; Jump depending on the alignment
 bi	    [r3]
 ; Read 3 bytes
 ldb.ab	r10,	[r13,	+1]
@@ -71,8 +71,6 @@ ldb.ab	r10,	[r13,	+1]
 cmp		r10,	0
 beq				@.L_return_size
 
-; Last nop can be removed [2]
-
 ; By this point, r13 is either 4 or 8 byte aligned
 .L_4B_step:
 
@@ -86,7 +84,7 @@ ld.ab	r10,	[r13,	+4]
 sub		r11,	r10,	NULL_32DT_1
 bic		r11,	r11,	r10
 tst		r11,	NULL_32DT_2
-bne		@.L_reread_last_4bytes
+bne				@.L_reread_last_4bytes
 
 .L_start_4_8B_search:
 ; Setup byte detector (more information bellow) [3] [5]
@@ -97,6 +95,7 @@ orl		r8,		r8,		NULL_32DT_1
 orl		r9,		r9,		NULL_32DT_2
 
 ldl.ab	r2,		[r13,	+8]
+
 .L_4_8B_search:
 		ldl.ab	r3,		[r13,	+8]
 		ldl.ab	r4,		[r13,	+8]
@@ -113,20 +112,20 @@ ldl.ab	r2,		[r13,	+8]
 		bicl	r12,	r12,	r4
 		bicl	r7,		r7,		r5
 
-		tstl	r10,	r9
-		xor.ne	r6,		r6,		0b10000
+		tstl		r10,	r9
+		bset.ne		r6,		r6,		4
 
-		tstl	r11,	r9
-		xor.ne	r6,		r6,		0b01000
+		tstl		r11,	r9
+		bset.ne		r6,		r6,		3
 
-		tstl	r12,	r9
-		xor.ne	r6,		r6,		0b00100
+		tstl		r12,	r9
+		bset.ne		r6,		r6,		2
 
-		tstl	r7,		r9
-		xor.ne	r6,		r6,		0b00010
+		tstl		r7,		r9
+		bset.ne		r6,		r6,		1
 
-		breq.d	r6,		0,		@.L_4_8B_search
-		ldl.ab	r2,		[r13,	+8]
+		breq.d		r6,		0,		@.L_4_8B_search
+		ldl.ab		r2,		[r13,	+8]
 
 ; Back track only what is required [4]
 fls		r6,		r6

--- a/newlib/libc/machine/arc64/strlen.S
+++ b/newlib/libc/machine/arc64/strlen.S
@@ -31,31 +31,28 @@
 #include <sys/asm.h>
 
 ; Brief:
-; If 4 byte aligned
-; 	Do 4 byte NULL byte search
-;	When it is found, perfom a 1 byte search on the last 4 bytes
-; Otherwise, 1 byte search until alignment
-;	Then, do 4 byte search as previously specified
-;
-;; More in depth description at the end
+; This code "fixes" alignment of the input pointer and performs 8 byte searches
+; in 32 byte chunks.
+; It is therefore optimized for big strings, presenting some overhead for
+; smaller strings
 ;
 ; R0 const char* ptr
 ; ret (R0):
 ;		- String size
+
 #if defined (__ARC64_ARCH64__)
 
 ENTRY (strlen)
 
-	; address is 4 byte aligned, go to 4 byte search
+; If address is 4 byte aligned, we can just directly read 4 bytes
 	bmsk.f	r3,		r0,		1
 	beq.d			@.L_start_4byte_search
 	MOVP	r13,	r0	; Store r0 for size calculation
 
 	subl	r3,		r3,		1		; [0]
 	asl		r3,		r3,		2		; [1]
-;	add		r3,		r3,		r2		; x3
 
-	; r3 now represents the inverse of the amount of instructions to skip
+; Jump depending on the alignment
 	bi	    [r3]
 ; Read 3 bytes
 	ldb.ab	r10,	[r13,	+1]
@@ -73,44 +70,73 @@ ENTRY (strlen)
 	beq				@.L_return_ptr
 	nop
 
+; r13 is now either 4 or 8 byte aligned
 .L_start_4byte_search:
-	;; Setup byte detector (more information bellow)
-	MOVP	r8,		NULL_DT_1
-	ror		r9,		r8			; Less cycles than moving than LIMM with NULL_DT_2
 
-; Is it aligned to 4 or 8 bytes?
-	andl.f	0,		r13,		0x7
-	beq		@1f
+; If aligned to 8 bytes, just jump ahead
+	andl.f	0,		r13,	0b111
+	beq.d	@1f
+	xorl	r6,		r6,		r6	; reset mask showing NULL byte location
 
 	ld.ab	r10,	[r13,	+4]
-	cmp		r10,	0
-	beq			@.L_return_ptr
-
+	sub		r8,		r10,	NULL_32DT_1
+	bic		r8,		r8,		r10
+	tst		r8,		NULL_32DT_2
+	bne.d		@.L_reread_last_4bytes
+	xorl	r9,		r9,		r9
 
 1:
-	; Load next 4 bytes
-	ldl.ab	r10,	[r13, +8]
+; Setup byte detector (more information bellow) [2]
+	movhl	r8,		NULL_32DT_1
+	orl		r8,		r8,		NULL_32DT_1
 
-; Handle 4 byte chunks
-.L_search8byte_chunk:
-	
-	; Look for the NULL byte
-	sub		r2,		r10,	r8
-	bicl	r2,		r2,		r10
-	tst		r2,		r9
+	movhl	r9,		NULL_32DT_2
+	orl		r9,		r9,		NULL_32DT_2
 
-	; NULL byte not found yet
-	beq.d	@.L_search8byte_chunk
-	; Load next 4 bytes
-	ldl.ab	r10,	[r13, +8]
-	
-; NULL byte found!
-; Backtrack 8 bytes [2]
-	subl	r13,		r13,		24
+	ldl.ab	  r2,	[r13, +8]
+.L_search_32bytes:
+	ldl.ab	  r3,	[r13, +8]
+	ldl.ab	  r4,	[r13, +8]
+	ldl.ab	  r5,	[r13, +8]
 
-	ldb		r10,	[r13]
+; If there is a 0 in any of the read 32 bytes, its location is encoded
+; in r6 as a bit mask
+; This bitmask can be used to calculate the appropriate regression in the pointer [3]
+	subl	r10,	r2,		r8
+	bicl	r10,	r10,	r2
+	tstl	r10,	r9
+	xor.ne	r6,		r6,		0b10000
+
+	subl	r11,	r3,		r8
+	bicl	r11,	r11,	r3
+	tstl	r11,	r9
+	xor.ne	r6,		r6,		0b01000
+
+	subl	r12,	r4,		r8
+	bicl	r12,	r12,	r4
+	tstl	r12,	r9
+	xor.ne	r6,		r6,		0b00100
+
+	subl	r7,		r5,		r8
+	bicl	r7,		r7,		r5
+	tstl	r7,		r9
+	xor.ne	r6,		r6,		0b00010
+
+	breq.d	r6,		0,		@.L_search_32bytes
+	ldl.ab	r2,		[r13,	+8]
+
+; Back track only what is required [4]
+fls		r6,		r6
+asl		r6,		r6,		3
+subl	r13,	r13,	r6
+
+; Compensate writeback
+subl	r13,	r13,	4
+.L_reread_last_4bytes:
+subl	r13,	r13,	4
 
 ;; 1 byte search until NULL byte is found
+ldb		r10,	[r13]
 .L_search_next_1byte_chunk:
 	cmp		r10,	0
 	bne.d	@.L_search_next_1byte_chunk
@@ -123,7 +149,11 @@ ENTRY (strlen)
 	subl	r0,		r0,		1
 
 ;; The first step in this code is to "fix" the address alignment
-;; This is done by looking at the last 2 bits in the address, and infering
+;
+;; First, we check if the address is already 4 byte aligned.
+;; If so, we can simply read 4 bytes and start the 8 byte reads
+;
+;; Otherwise, we can look at the last 2 bits in the address, and infer
 ;; how many 1 byte loads are required
 ; The following table shows how the last two bytes correlate to branch index
 ; and how many bytes we need to read
@@ -135,8 +165,9 @@ ENTRY (strlen)
 ;   10b (2) |        2        |        1       |   4
 ;   11b (3) |        1        |        2       |   8
 ;
-; Removing 1 from b1b0 [0] gives us the branch index.
-; Now to get the appropriate jump size, we can just multiply by 4 [1]
+; Removing 1 from b1b0 [0] gives us the "branch index".
+; Now to get the appropriate jump size (how many instructions there are per branch)
+; we can just multiply by 4 [1]
 ;
 ;; This code uses a common technique for NULL byte detection inside a word.
 ;; Details on this technique can be found in:
@@ -147,12 +178,20 @@ ENTRY (strlen)
 ; 		DETECTNULL(X) (((X) - 0x01010101) & ~(X) & 0x80808080)
 ;
 ; The code above implements this by setting r8 to 0x01010101 and r9 to 0x80808080
+; This operation differs slightly between 64 bit and 32 bit analizysis, as LIMM are 32
+; bit only, we need to perform MOVHL and ORL [2] operations to have the appropriate 64bit
+; values in place
 ;
-;; There are a few possible optimizations identified
+;; The major optimization in this code is to perform several 8 load byte loads
+;; in a row and using the previously mentioned NULL byte detection method to find
+;; the end of the string
 ;
-; [2]
-; Dont reload from memory, but instead use the current value of r11
-; There might be a possible problem due to endianness
+; To achieve this, finding a NULL byte sets a bitmask that [3], when passed via
+; the "find last set" instruction returns the amount of 8 byte chunks to backtrack
+; We can then simply multiply by 8 and remove that value from the pointer
+;
+;
+;
 
 ENDFUNC (strlen)
 #endif

--- a/newlib/libc/machine/arc64/strlen.S
+++ b/newlib/libc/machine/arc64/strlen.S
@@ -50,7 +50,7 @@ ENTRY (strlen)
 	beq.d			@.L_start_4byte_search
 	MOVP	r13,	r0	; Store r0 for size calculation
 
-	SUBP	r3,		r3,		1		; [0]
+	subl	r3,		r3,		1		; [0]
 	asl		r3,		r3,		2		; [1]
 
 	; r3 now represents the inverse of the amount of instructions to skip
@@ -59,17 +59,17 @@ ENTRY (strlen)
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
 	beq.d			@.L_return_ptr
-	SUBP	r2,		r2,		1
+	subl	r2,		r2,		1
 ; Read 2 bytes
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
 	beq.d			@.L_return_ptr
-	SUBP	r2,		r2,		1
+	subl	r2,		r2,		1
 ; Read 1 byte
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
 	beq.d			@.L_return_ptr
-	SUBP	r2,		r2,		1
+	subl	r2,		r2,		1
 
 
 .L_start_4byte_search:
@@ -97,7 +97,7 @@ ENTRY (strlen)
 ; Backtrack 8 bytes [2]
 ; 4 because of write-back, 4 because we dont know for sure where in the
 ; 4 bytes the NULL byte is. Then perform 1 byte search
-	SUBP	r13,		r13,		8
+	subl	r13,		r13,		8
 
 	ldb		r10,	[r13]
 
@@ -109,9 +109,9 @@ ENTRY (strlen)
 
 ; NULL byte was found in r0 - 1
 .L_return_ptr:
-	SUBP	r0,		r13,		r0
+	subl	r0,		r13,		r0
 	j_s.d	[blink]
-	SUBP	r0,		r0,		1
+	subl	r0,		r0,		1
 
 ;; The first step in this code is to "fix" the address alignment
 ;; This is done by looking at the last 2 bits in the address, and infering

--- a/newlib/libc/machine/arc64/strlen.S
+++ b/newlib/libc/machine/arc64/strlen.S
@@ -42,6 +42,7 @@
 ; R0 const char* ptr
 ; ret (R0):
 ;		- String size
+#if defined (__ARC64_ARCH64__)
 
 ENTRY (strlen)
 
@@ -52,52 +53,60 @@ ENTRY (strlen)
 
 	subl	r3,		r3,		1		; [0]
 	asl		r3,		r3,		2		; [1]
+;	add		r3,		r3,		r2		; x3
 
 	; r3 now represents the inverse of the amount of instructions to skip
 	bi	    [r3]
 ; Read 3 bytes
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
-	beq.d			@.L_return_ptr
-	subl	r2,		r2,		1
+	beq 			@.L_return_ptr
+	nop
 ; Read 2 bytes
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
-	beq.d			@.L_return_ptr
-	subl	r2,		r2,		1
+	beq				@.L_return_ptr
+	nop
 ; Read 1 byte
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
-	beq.d			@.L_return_ptr
-	subl	r2,		r2,		1
-
+	beq				@.L_return_ptr
+	nop
 
 .L_start_4byte_search:
 	;; Setup byte detector (more information bellow)
-	mov		r8,		0x01010101
-	ror		r9,		r8
+	MOVP	r8,		NULL_DT_1
+	ror		r9,		r8			; Less cycles than moving than LIMM with NULL_DT_2
 
+; Is it aligned to 4 or 8 bytes?
+	andl.f	0,		r13,		0x7
+	beq		@1f
+
+	ld.ab	r10,	[r13,	+4]
+	cmp		r10,	0
+	beq			@.L_return_ptr
+
+
+1:
 	; Load next 4 bytes
-	ld.ab	r10,	[r13, +4]
+	ldl.ab	r10,	[r13, +8]
 
 ; Handle 4 byte chunks
-.L_search4byte_chunk:
+.L_search8byte_chunk:
 	
 	; Look for the NULL byte
 	sub		r2,		r10,	r8
-	bic		r2,		r2,		r10
+	bicl	r2,		r2,		r10
 	tst		r2,		r9
 
 	; NULL byte not found yet
-	beq.d	@.L_search4byte_chunk
+	beq.d	@.L_search8byte_chunk
 	; Load next 4 bytes
-	ld.ab	r10,	[r13, +4]
+	ldl.ab	r10,	[r13, +8]
 	
 ; NULL byte found!
 ; Backtrack 8 bytes [2]
-; 4 because of write-back, 4 because we dont know for sure where in the
-; 4 bytes the NULL byte is. Then perform 1 byte search
-	subl	r13,		r13,		8
+	subl	r13,		r13,		24
 
 	ldb		r10,	[r13]
 
@@ -146,3 +155,4 @@ ENTRY (strlen)
 ; There might be a possible problem due to endianness
 
 ENDFUNC (strlen)
+#endif

--- a/newlib/libc/machine/arc64/strlen.S
+++ b/newlib/libc/machine/arc64/strlen.S
@@ -103,22 +103,24 @@ ENTRY (strlen)
 ; in r6 as a bit mask
 ; This bitmask can be used to calculate the appropriate regression in the pointer [3]
 	subl	r10,	r2,		r8
+	subl	r11,	r3,		r8
+	subl	r12,	r4,		r8
+	subl	r7,		r5,		r8
+
 	bicl	r10,	r10,	r2
+	bicl	r11,	r11,	r3
+	bicl	r12,	r12,	r4
+	bicl	r7,		r7,		r5
+
 	tstl	r10,	r9
 	xor.ne	r6,		r6,		0b10000
 
-	subl	r11,	r3,		r8
-	bicl	r11,	r11,	r3
 	tstl	r11,	r9
 	xor.ne	r6,		r6,		0b01000
 
-	subl	r12,	r4,		r8
-	bicl	r12,	r12,	r4
 	tstl	r12,	r9
 	xor.ne	r6,		r6,		0b00100
 
-	subl	r7,		r5,		r8
-	bicl	r7,		r7,		r5
 	tstl	r7,		r9
 	xor.ne	r6,		r6,		0b00010
 

--- a/newlib/libc/machine/arc64/strlen.S
+++ b/newlib/libc/machine/arc64/strlen.S
@@ -1,0 +1,91 @@
+/*
+   Copyright (c) 2021, Synopsys, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1) Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2) Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+   3) Neither the name of the Synopsys, Inc., nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sys/asm.h>
+
+ENTRY (strlen)
+	; If the address is already 4 byte aligned, just jump to 4 byte search
+	bmsk.f	0,		r0,		1
+	beq.d	@.L_start_4byte_search
+	MOVP	r13,	r0	; Store r0 for size calculation
+
+.L_start_1byte_search:
+	; 1 byte search until 4 byte alignment is found
+	ldb		r10,	[r13]
+	cmp		r10,	0
+
+.L_search_next_1byte_chunk:
+	; Found NULL byte!
+	beq.d	@.L_return_ptr
+	ldb.aw	r10,	[r13, +1]
+
+	; 4 byte alignment not reached yet
+	bmsk.f	0,		r13,		1
+	bne.d	@.L_search_next_1byte_chunk
+	cmp		r10,	0
+
+; 4 byte alignment reached!
+
+; Bootstrap magic NULL byte detector for 4 byte search
+.L_start_4byte_search:
+	mov		r8,		0x01010101
+	ror		r9,		r8						; Further magic byte detector setup
+
+	; Load next 4 bytes
+	ld.ab	r10,	[r13, +4]
+
+; Handle 4 byte chunks
+.L_search4byte_chunk:
+	
+	; Look for the NULL byte
+	sub		r2,		r10,	r8
+	bic		r2,		r2,		r10
+	tst		r2,		r9
+
+	; byte not found yet
+	beq.d	@.L_search4byte_chunk
+	; Load next 4 bytes
+	ld.ab	r10,	[r13, +4]
+	
+	; NULL byte found!
+	; Backtrack 8 bytes
+	; 4 because of write-back, 4 because we dont know for sure where in the
+	; 4 bytes the NULL byte is
+	; Then let 1 byte search do its' thing
+	SUBP	r13,		r13,		8
+	j		@.L_start_1byte_search
+
+; Byte was found in r0 - 1
+.L_return_ptr:
+	SUBP	r0,		r13,		r0
+	j_s.d	[blink]
+	SUBP	r0,		r0,		1
+
+ENDFUNC (strlen)

--- a/newlib/libc/machine/arc64/strlen.S
+++ b/newlib/libc/machine/arc64/strlen.S
@@ -30,33 +30,52 @@
 
 #include <sys/asm.h>
 
+; Brief:
+; If 4 byte aligned
+; 	Do 4 byte NULL byte search
+;	When it is found, perfom a 1 byte search on the last 4 bytes
+; Otherwise, 1 byte search until alignment
+;	Then, do 4 byte search as previously specified
+;
+;; More in depth description at the end
+;
+; R0 const char* ptr
+; ret (R0):
+;		- String size
+
 ENTRY (strlen)
-	; If the address is already 4 byte aligned, just jump to 4 byte search
-	bmsk.f	0,		r0,		1
-	beq.d	@.L_start_4byte_search
+
+	; address is 4 byte aligned, go to 4 byte search
+	bmsk.f	r3,		r0,		1
+	beq.d			@.L_start_4byte_search
 	MOVP	r13,	r0	; Store r0 for size calculation
 
-.L_start_1byte_search:
-	; 1 byte search until 4 byte alignment is found
-	ldb		r10,	[r13]
+	SUBP	r3,		r3,		1		; [0]
+	asl		r3,		r3,		2		; [1]
+
+	; r3 now represents the inverse of the amount of instructions to skip
+	bi	    [r3]
+; Read 3 bytes
+	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
-
-.L_search_next_1byte_chunk:
-	; Found NULL byte!
-	beq.d	@.L_return_ptr
-	ldb.aw	r10,	[r13, +1]
-
-	; 4 byte alignment not reached yet
-	bmsk.f	0,		r13,		1
-	bne.d	@.L_search_next_1byte_chunk
+	beq.d			@.L_return_ptr
+	SUBP	r2,		r2,		1
+; Read 2 bytes
+	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
+	beq.d			@.L_return_ptr
+	SUBP	r2,		r2,		1
+; Read 1 byte
+	ldb.ab	r10,	[r13,	+1]
+	cmp		r10,	0
+	beq.d			@.L_return_ptr
+	SUBP	r2,		r2,		1
 
-; 4 byte alignment reached!
 
-; Bootstrap magic NULL byte detector for 4 byte search
 .L_start_4byte_search:
+	;; Setup byte detector (more information bellow)
 	mov		r8,		0x01010101
-	ror		r9,		r8						; Further magic byte detector setup
+	ror		r9,		r8
 
 	; Load next 4 bytes
 	ld.ab	r10,	[r13, +4]
@@ -69,23 +88,61 @@ ENTRY (strlen)
 	bic		r2,		r2,		r10
 	tst		r2,		r9
 
-	; byte not found yet
+	; NULL byte not found yet
 	beq.d	@.L_search4byte_chunk
 	; Load next 4 bytes
 	ld.ab	r10,	[r13, +4]
 	
-	; NULL byte found!
-	; Backtrack 8 bytes
-	; 4 because of write-back, 4 because we dont know for sure where in the
-	; 4 bytes the NULL byte is
-	; Then let 1 byte search do its' thing
+; NULL byte found!
+; Backtrack 8 bytes [2]
+; 4 because of write-back, 4 because we dont know for sure where in the
+; 4 bytes the NULL byte is. Then perform 1 byte search
 	SUBP	r13,		r13,		8
-	j		@.L_start_1byte_search
 
-; Byte was found in r0 - 1
+	ldb		r10,	[r13]
+
+;; 1 byte search until NULL byte is found
+.L_search_next_1byte_chunk:
+	cmp		r10,	0
+	bne.d	@.L_search_next_1byte_chunk
+	ldb.aw	r10,	[r13, +1]
+
+; NULL byte was found in r0 - 1
 .L_return_ptr:
 	SUBP	r0,		r13,		r0
 	j_s.d	[blink]
 	SUBP	r0,		r0,		1
+
+;; The first step in this code is to "fix" the address alignment
+;; This is done by looking at the last 2 bits in the address, and infering
+;; how many 1 byte loads are required
+; The following table shows how the last two bytes correlate to branch index
+; and how many bytes we need to read
+;
+;   (b1,b0) | bytes to search |  branch index  | required jump
+; ----------+-----------------+----------------+--------------
+;   00b (0) |   <---  Already aligned, jumps directly to 4 byte search
+;   01b (1) |        3        |        0       |   0
+;   10b (2) |        2        |        1       |   4
+;   11b (3) |        1        |        2       |   8
+;
+; Removing 1 from b1b0 [0] gives us the branch index.
+; Now to get the appropriate jump size, we can just multiply by 4 [1]
+;
+;; This code uses a common technique for NULL byte detection inside a word.
+;; Details on this technique can be found in:
+;; (https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord)
+;
+; In sum, this technique allows for detecting a NULL byte inside any given amount of
+; bits by performing the following operation
+; 		DETECTNULL(X) (((X) - 0x01010101) & ~(X) & 0x80808080)
+;
+; The code above implements this by setting r8 to 0x01010101 and r9 to 0x80808080
+;
+;; There are a few possible optimizations identified
+;
+; [2]
+; Dont reload from memory, but instead use the current value of r11
+; There might be a possible problem due to endianness
 
 ENDFUNC (strlen)

--- a/newlib/libc/machine/arc64/sys/asm.h
+++ b/newlib/libc/machine/arc64/sys/asm.h
@@ -35,8 +35,6 @@
  * Macros to handle different pointer/register sizes for 32/64-bit code
  */
 #if defined (__ARC64_ARCH32__)
-# define NULL_DT_1 0x01010101
-# define NULL_DT_2 0x80808080
 # define ST64  std
 # define LD64  ldd
 # define MOVP  mov
@@ -45,8 +43,6 @@
 # define REG_ST st
 # define REG_LD ld
 #elif defined (__ARC64_ARCH64__)
-# define NULL_DT_1 0x0101010101010101
-# define NULL_DT_2 0x8080808080808080
 # define ST64  stl
 # define LD64  ldl
 # define MOVP  movl
@@ -57,6 +53,9 @@
 #else
 # error Please use either 32-bit or 64-bit version of arc64 compiler
 #endif
+
+# define NULL_32DT_1 0x01010101
+# define NULL_32DT_2 0x80808080
 
 #define _ENTRY(name) \
 	.text ` .balign 4 ` .globl name ` name:

--- a/newlib/libc/machine/arc64/sys/asm.h
+++ b/newlib/libc/machine/arc64/sys/asm.h
@@ -35,6 +35,8 @@
  * Macros to handle different pointer/register sizes for 32/64-bit code
  */
 #if defined (__ARC64_ARCH32__)
+# define NULL_DT_1 0x01010101
+# define NULL_DT_2 0x80808080
 # define ST64  std
 # define LD64  ldd
 # define MOVP  mov
@@ -43,6 +45,8 @@
 # define REG_ST st
 # define REG_LD ld
 #elif defined (__ARC64_ARCH64__)
+# define NULL_DT_1 0x0101010101010101
+# define NULL_DT_2 0x8080808080808080
 # define ST64  stl
 # define LD64  ldl
 # define MOVP  movl


### PR DESCRIPTION
Created assembly version of strlen with the objective of focusing on speed for larger amounts of memory/bigger strings.
Used measure of speed is instruction count from NSIM, via CPU counters.
Measurements against compiler generated code suggest a decrease in instruction count of 45% for bigger strings (200 bytes) and a penalty of 15% for smaller strings (14 bytes).
