### PR TITLE
Optimized strcat implementation

### DIFF
--- a/newlib/libc/machine/arc64/Makefile.am
+++ b/newlib/libc/machine/arc64/Makefile.am
@@ -14,6 +14,7 @@ lib_a_SOURCES =                 \
         memset.S                \
         memset-stub.c           \
         strlen.S                \
+        strcat.S                \
         setjmp.S
 
 lib_a_CCASFLAGS=$(AM_CCASFLAGS)

--- a/newlib/libc/machine/arc64/Makefile.in
+++ b/newlib/libc/machine/arc64/Makefile.in
@@ -121,7 +121,8 @@ lib_a_LIBADD =
 am_lib_a_OBJECTS = lib_a-memcmp.$(OBJEXT) lib_a-memcmp-stub.$(OBJEXT) \
 	lib_a-memcpy.$(OBJEXT) lib_a-memcpy-stub.$(OBJEXT) \
 	lib_a-memset.$(OBJEXT) lib_a-memset-stub.$(OBJEXT) \
-	lib_a-strlen.$(OBJEXT) lib_a-setjmp.$(OBJEXT)
+	lib_a-strlen.$(OBJEXT) lib_a-strcat.$(OBJEXT) \
+	lib_a-setjmp.$(OBJEXT)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -347,6 +348,7 @@ lib_a_SOURCES = \
         memset.S                \
         memset-stub.c           \
         strlen.S                \
+        strcat.S                \
         setjmp.S
 
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
@@ -431,6 +433,12 @@ lib_a-strlen.o: strlen.S
 
 lib_a-strlen.obj: strlen.S
 	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strlen.obj `if test -f 'strlen.S'; then $(CYGPATH_W) 'strlen.S'; else $(CYGPATH_W) '$(srcdir)/strlen.S'; fi`
+
+lib_a-strcat.o: strcat.S
+	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strcat.o `test -f 'strcat.S' || echo '$(srcdir)/'`strcat.S
+
+lib_a-strcat.obj: strcat.S
+	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strcat.obj `if test -f 'strcat.S'; then $(CYGPATH_W) 'strcat.S'; else $(CYGPATH_W) '$(srcdir)/strcat.S'; fi`
 
 lib_a-setjmp.o: setjmp.S
 	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-setjmp.o `test -f 'setjmp.S' || echo '$(srcdir)/'`setjmp.S

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -55,6 +55,8 @@
 ;		- 0 : Byte not found
 ;		- Byte position
 
+#if defined (__ARC64_ARCH64__)
+
 ENTRY (strcat)
 ; Find end of r0
 ; ========================== STRLEN CODE START ==========================
@@ -67,7 +69,7 @@ ENTRY (strcat)
 	beq.d			@.L_start_4byte_search
 	MOVP	r13,	r0	; Store r0 for size calculation
 
-	SUBP	r3,		r3,		1		; [0]
+	subl	r3,		r3,		1		; [0]
 	asl		r3,		r3,		2		; [1]
 
 	; r3 now represents the inverse of the amount of instructions to skip
@@ -76,17 +78,17 @@ ENTRY (strcat)
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
 	beq.d			@.L_string_end_found
-	SUBP	r2,		r2,		1
+	subl	r2,		r2,		1
 ; Read 2 bytes
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
 	beq.d			@.L_string_end_found
-	SUBP	r2,		r2,		1
+	subl	r2,		r2,		1
 ; Read 1 byte
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
 	beq.d			@.L_string_end_found
-	SUBP	r2,		r2,		1
+	subl	r2,		r2,		1
 
 .L_start_4byte_search:
 
@@ -110,7 +112,7 @@ ENTRY (strcat)
 ; Backtrack 8 bytes [2]
 ; 4 because of write-back, 4 because we dont know for sure where in the
 ; 4 bytes the NULL byte is. Then perform 1 byte search
-SUBP	r13,		r13,		8
+subl	r13,		r13,		8
 ldb		r10,	[r13]
 
 ;; 1 byte search until NULL byte is found
@@ -121,7 +123,7 @@ ldb		r10,	[r13]
 
 ; NULL byte was found in r0 - 1
 .L_string_end_found:
-	SUBP	r13,		r13,	1
+	subl	r13,		r13,	1
 
 ; ========================== STRLEN CODE END >|< ==========================
 
@@ -137,7 +139,7 @@ ldb		r10,	[r13]
 	bmsk.f	r3,		r13,		1
 	beq.d			@.L_start_4byte_search_src
 
-	SUBP	r3,		r3,		1		; [0]
+	subl	r3,		r3,		1		; [0]
 	asl		r3,		r3,		2		; [1]
 
 	; r3 now represents the inverse of the amount of instructions to skip
@@ -183,7 +185,7 @@ bne.d	@.L_start_search_next_1byte_chunk
 
 .L_start_search_next_1byte_chunk:
 
-SUBP	r1,     r1,     4
+subl	r1,     r1,     4
 
 .L_start_1byte_search:
 
@@ -199,3 +201,5 @@ SUBP	r1,     r1,     4
 
 
 ENDFUNC (strcat)
+
+#endif

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -60,11 +60,7 @@
 ENTRY (strcat)
 ; Find end of r0
 ; ========================== STRLEN CODE START ==========================
-	;; Setup byte detector (more information bellow)
-	mov		r8,		0x01010101
-	ror		r9,		r8
-    
-	; address is 4 byte aligned, go to 4 byte search
+; If address is 4 byte aligned, we can just directly read 4 bytes
 	bmsk.f	r3,		r0,		1
 	beq.d			@.L_start_4byte_search
 	MOVP	r13,	r0	; Store r0 for size calculation
@@ -72,50 +68,92 @@ ENTRY (strcat)
 	subl	r3,		r3,		1		; [0]
 	asl		r3,		r3,		2		; [1]
 
-	; r3 now represents the inverse of the amount of instructions to skip
+; Jump depending on the alignment
 	bi	    [r3]
 ; Read 3 bytes
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
-	beq.d			@.L_string_end_found
-	subl	r2,		r2,		1
+	beq 			@.L_string_end_found
+	nop
 ; Read 2 bytes
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
-	beq.d			@.L_string_end_found
-	subl	r2,		r2,		1
+	beq				@.L_string_end_found
+	nop
 ; Read 1 byte
 	ldb.ab	r10,	[r13,	+1]
 	cmp		r10,	0
-	beq.d			@.L_string_end_found
-	subl	r2,		r2,		1
+	beq				@.L_string_end_found
+	nop
 
+; r13 is now either 4 or 8 byte aligned
 .L_start_4byte_search:
 
-	; Load next 4 bytes
-	ld.ab	r10,	[r13, +4]
+; If aligned to 8 bytes, just jump ahead
+	andl.f	0,		r13,	0b111
+	beq.d	@1f
+	xorl	r6,		r6,		r6	; reset mask showing NULL byte location
 
-; Handle 4 byte chunks
-.L_search4byte_chunk:
-	
-	; Look for the NULL byte
-	sub		r2,		r10,	r8
-	bic		r2,		r2,		r10
-	tst		r2,		r9
+	ld.ab	r10,	[r13,	+4]
+	sub		r11,	r10,	NULL_32DT_1
+	bic		r11,	r11,	r10
+	tst		r11,	NULL_32DT_2
+	bne		@.L_reread_last_4bytes
 
-	; NULL byte not found yet
-	beq.d	@.L_search4byte_chunk
-	; Load next 4 bytes
-	ld.ab	r10,	[r13, +4]
-	
-; NULL byte found!
-; Backtrack 8 bytes [2]
-; 4 because of write-back, 4 because we dont know for sure where in the
-; 4 bytes the NULL byte is. Then perform 1 byte search
-subl	r13,		r13,		8
-ldb		r10,	[r13]
+1:
+; Setup byte detector (more information bellow) [2]
+	movhl	r8,		NULL_32DT_1
+	orl		r8,		r8,		NULL_32DT_1
+
+	movhl	r9,		NULL_32DT_2
+	orl		r9,		r9,		NULL_32DT_2
+
+	ldl.ab	  r2,	[r13, +8]
+.L_search_32bytes:
+	ldl.ab	  r3,	[r13, +8]
+	ldl.ab	  r4,	[r13, +8]
+	ldl.ab	  r5,	[r13, +8]
+
+; If there is a 0 in any of the read 32 bytes, its location is encoded
+; in r6 as a bit mask
+; This bitmask can be used to calculate the appropriate regression in the pointer [3]
+	subl	r10,	r2,		r8
+	subl	r11,	r3,		r8
+	subl	r12,	r4,		r8
+	subl	r7,		r5,		r8
+
+	bicl	r10,	r10,	r2
+	bicl	r11,	r11,	r3
+	bicl	r12,	r12,	r4
+	bicl	r7,		r7,		r5
+
+	tstl		r10,	r9
+	bset.ne		r6,		r6,		4
+
+	tstl		r11,	r9
+	bset.ne		r6,		r6,		3
+
+	tstl		r12,	r9
+	bset.ne		r6,		r6,		2
+
+	tstl		r7,		r9
+	bset.ne		r6,		r6,		1
+
+	breq.d	r6,		0,		@.L_search_32bytes
+	ldl.ab	r2,		[r13,	+8]
+
+; Back track only what is required [4]
+fls		r6,		r6
+asl		r6,		r6,		3
+subl	r13,	r13,	r6
+
+; Compensate writeback
+subl	r13,	r13,	4
+.L_reread_last_4bytes:
+subl	r13,	r13,	4
 
 ;; 1 byte search until NULL byte is found
+ldb		r10,	[r13]
 .L_search_next_1byte_chunk:
 	cmp		r10,	0
 	bne.d	@.L_search_next_1byte_chunk
@@ -123,7 +161,8 @@ ldb		r10,	[r13]
 
 ; NULL byte was found in r0 - 1
 .L_string_end_found:
-	subl	r13,		r13,	1
+	subl	r13,	r13,		1
+
 
 ; ========================== STRLEN CODE END >|< ==========================
 
@@ -133,8 +172,8 @@ ldb		r10,	[r13]
 	SUB.f		r10,		r10,	    r11
 
 	; If alignments are different, will never match alignment
-	bne		@.L_start_1byte_search
-    
+	bne		@.L_start_1byte_search_src
+
     ; Aligned at 4 byte!
 	bmsk.f	r3,		r13,		1
 	beq.d			@.L_start_4byte_search_src
@@ -160,40 +199,93 @@ ldb		r10,	[r13]
 	beq.d			@.L_return_ptr
     stb.ab	r10,	[r13,	+1]
 
+
+; r13 is now either 4 or 8 byte aligned
 .L_start_4byte_search_src:
 
-ld.ab	r11,	[r1, +4]
-sub		r12, r11, r8
-bic		r12, r12, r11
-tst		r12, r9
-bne.d	@.L_start_search_next_1byte_chunk
+; If aligned to 8 bytes, just jump ahead
+	andl.f	0,		r1,		0b111
+	beq.d	@.L_search_32bytes_src
+	xorl	r6,		r6,		r6	; reset mask showing NULL byte location
 
-.L_copy_4byte_chunk:
-	; Set r10 to be the previously read 4 bytes
-    ; Move known non NULL containing bytes to r10
-	MOVP	r10,    r11
-	; Read next 4 bytes
-	ld.ab	r11,	[r1, +4]
-	; Check if NULL byte is in the next 4 bytes
-	sub		r12,    r11,    r8
-	bic		r12,    r12,    r11
-	tst		r12,    r9
+	ld.ab	r10,	[r1,	+4]
+	sub		r11,	r10,	NULL_32DT_1
+	bic		r11,	r11,	r10
+	tst		r11,	NULL_32DT_2
+	bne		@.L_reread_last_4bytes_src
 
-	; NULL byte not found, store previous non-NULL byte containing bytes and continue
-	beq.d	@.L_copy_4byte_chunk
-	st.ab	r10,	[r13, +4]
+	stl.ab	r10,	[r13,	+4]
 
-.L_start_search_next_1byte_chunk:
+.L_search_32bytes_src:
+	ldl.ab	r2,	[r1,	+8]
+	ldl.ab	r3,	[r1,	+8]
+	ldl.ab	r4,	[r1,	+8]
+	ldl.ab	r5,	[r1,	+8]
+
+; If there is a 0 in any of the read 32 bytes, its location is encoded
+; in r6 as a bit mask
+; This bitmask can be used to calculate the appropriate regression in the pointer [3]
+	subl	r10,	r2,		r8
+	subl	r11,	r3,		r8
+	subl	r12,	r4,		r8
+	subl	r7,		r5,		r8
+
+	bicl	r10,	r10,	r2
+	bicl	r11,	r11,	r3
+	bicl	r12,	r12,	r4
+	bicl	r7,		r7,		r5
+
+	tstl		r10,	r9
+	bset.ne		r6,		r6,		4
+
+	tstl		r11,	r9
+	bset.ne		r6,		r6,		3
+
+	tstl		r12,	r9
+	bset.ne		r6,		r6,		2
+
+	tstl		r7,		r9
+	bset.ne		r6,		r6,		1
+
+	brne	r6,		0,		@.L_found_in_32B
+
+	stl.ab	r2,	[r13,	+8]
+	stl.ab	r3,	[r13,	+8]
+	stl.ab	r4,	[r13,	+8]
+	stl.ab	r5,	[r13,	+8]
+
+	j @.L_search_32bytes_src
+
+.L_found_in_32B:
+
+; Back track only what is required [4]
+;fls		r6,		r6
+
+;bi		[r6]
+;stl.ab	r5,	[r13,	+8]
+;stl.ab	r4,	[r13,	+8]
+;stl.ab	r3,	[r13,	+8]
+;stl.ab	r2,	[r13,	+8]
+
+;asl		r6,		r6,		3
+;subl	r1,		r1,		r6
+
+; Compensate writeback
+;addl	r1,	r1,	4
+
+subl	r1,		r1,		28
+
+.L_reread_last_4bytes_src:
 
 subl	r1,     r1,     4
 
-.L_start_1byte_search:
+.L_start_1byte_search_src:
 
 	; Look for NULL byte
 	ldb.ab	r11,	[r1, +1]
 	cmp		r11,	0
 
-    bne.d   @.L_start_1byte_search
+    bne.d   @.L_start_1byte_search_src
 	stb.ab	r11,	[r13, +1]
 
 .L_return_ptr:

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -37,8 +37,7 @@
 ; dest and src MUST NOT intercept
 
 ; Brief:
-; Perform the same operation as strlen for finding the end
-; of r0
+; Perform the same operation as strlen for finding the end of r0 string
 ; If r0 and r1 have
 ; If 4 byte aligned
 ; 	Do 4 byte search until there are no more 4 byte chunks
@@ -48,250 +47,354 @@
 ;
 ;; More in depth description at the end
 ;
-; R0 void* ptr
-; R1 int ch
-; R2 size_t count
+; R0 char* dest (destination string)
+; R1 const char* src (source string)
 ; ret (R0):
-;		- 0 : Byte not found
-;		- Byte position
+;		- char* (destiantion string)
+;
 
 #if defined (__ARC64_ARCH64__)
 
 ENTRY (strcat)
-; Find end of r0
+; Find end of r0 string
 ; ========================== STRLEN CODE START ==========================
+
 ; If address is 4 byte aligned, we can just directly read 4 bytes
-	bmsk.f	r3,		r0,		1
-	beq.d			@.L_start_4byte_search
-	MOVP	r13,	r0	; Store r0 for size calculation
+bmsk.f	r3,		r0,		1
+beq.d			@.L_4B_step_dest
 
-	subl	r3,		r3,		1		; [0]
-	asl		r3,		r3,		2		; [1]
+; Store r0 for size calculation when returning
+MOVP	r13,	r0
 
-; Jump depending on the alignment
-	bi	    [r3]
+subl	r3,		r3,		1		; [0]
+asl		r3,		r3,		2		; [1]
+
+; Jump depending on the alignment.
+bi	    [r3]
 ; Read 3 bytes
-	ldb.ab	r10,	[r13,	+1]
-	cmp		r10,	0
-	beq 			@.L_string_end_found
-	nop
+ldb.ab	r10,	[r13,	+1]
+cmp		r10,	0
+beq 			@.L_string_end_found
+nop
 ; Read 2 bytes
-	ldb.ab	r10,	[r13,	+1]
-	cmp		r10,	0
-	beq				@.L_string_end_found
-	nop
+ldb.ab	r10,	[r13,	+1]
+cmp		r10,	0
+beq				@.L_string_end_found
+nop
 ; Read 1 byte
-	ldb.ab	r10,	[r13,	+1]
-	cmp		r10,	0
-	beq				@.L_string_end_found
-	nop
+ldb.ab	r10,	[r13,	+1]
+cmp		r10,	0
+beq				@.L_string_end_found
+nop
 
-; r13 is now either 4 or 8 byte aligned
-.L_start_4byte_search:
+; By this point, r13 is either 4 or 8 byte aligned
+.L_4B_step_dest:
 
 ; If aligned to 8 bytes, just jump ahead
-	andl.f	0,		r13,	0b111
-	beq.d	@1f
-	xorl	r6,		r6,		r6	; reset mask showing NULL byte location
+andl.f	0,		r13,	0b111
+beq.d			@.L_start_4_8B_search_dest
 
-	ld.ab	r10,	[r13,	+4]
-	sub		r11,	r10,	NULL_32DT_1
-	bic		r11,	r11,	r10
-	tst		r11,	NULL_32DT_2
-	bne		@.L_reread_last_4bytes
+; Always reset bit mask that will encode NULL byte location
+xorl	r6,		r6,		r6
 
-1:
-; Setup byte detector (more information bellow) [2]
-	movhl	r8,		NULL_32DT_1
-	orl		r8,		r8,		NULL_32DT_1
+ld.ab	r10,	[r13,	+4]
+sub		r11,	r10,	NULL_32DT_1
+bic		r11,	r11,	r10
+tst		r11,	NULL_32DT_2
+bne				@.L_reread_last_4bytes
 
-	movhl	r9,		NULL_32DT_2
-	orl		r9,		r9,		NULL_32DT_2
+.L_start_4_8B_search_dest:
+; Setup byte detector (more information bellow) [2] [4]
+movhl	r8,		NULL_32DT_1
+movhl	r9,		NULL_32DT_2
 
-	ldl.ab	  r2,	[r13, +8]
-.L_search_32bytes:
-	ldl.ab	  r3,	[r13, +8]
-	ldl.ab	  r4,	[r13, +8]
-	ldl.ab	  r5,	[r13, +8]
+orl		r8,		r8,		NULL_32DT_1
+orl		r9,		r9,		NULL_32DT_2
 
-; If there is a 0 in any of the read 32 bytes, its location is encoded
-; in r6 as a bit mask
-; This bitmask can be used to calculate the appropriate regression in the pointer [3]
-	subl	r10,	r2,		r8
-	subl	r11,	r3,		r8
-	subl	r12,	r4,		r8
-	subl	r7,		r5,		r8
+ldl.ab	r2,		[r13,	+8]
 
-	bicl	r10,	r10,	r2
-	bicl	r11,	r11,	r3
-	bicl	r12,	r12,	r4
-	bicl	r7,		r7,		r5
+.L_4_8B_search_dest:
+		ldl.ab	r3,		[r13,	+8]
+		ldl.ab	r4,		[r13,	+8]
+		ldl.ab	r5,		[r13,	+8]
 
-	tstl		r10,	r9
-	bset.ne		r6,		r6,		4
+	; NULL byte position is detected and encoded in r6 [3] [4]
+		subl	r10,	r2,		r8
+		subl	r11,	r3,		r8
+		subl	r12,	r4,		r8
+		subl	r7,		r5,		r8
 
-	tstl		r11,	r9
-	bset.ne		r6,		r6,		3
+		bicl	r10,	r10,	r2
+		bicl	r11,	r11,	r3
+		bicl	r12,	r12,	r4
+		bicl	r7,		r7,		r5
 
-	tstl		r12,	r9
-	bset.ne		r6,		r6,		2
+		tstl		r10,	r9
+		bset.ne		r6,		r6,		4
 
-	tstl		r7,		r9
-	bset.ne		r6,		r6,		1
+		tstl		r11,	r9
+		bset.ne		r6,		r6,		3
 
-	breq.d	r6,		0,		@.L_search_32bytes
-	ldl.ab	r2,		[r13,	+8]
+		tstl		r12,	r9
+		bset.ne		r6,		r6,		2
 
-; Back track only what is required [4]
+		tstl		r7,		r9
+		bset.ne		r6,		r6,		1
+
+		breq.d		r6,		0,		@.L_4_8B_search_dest
+		ldl.ab		r2,		[r13,	+8]
+
+; Back track only what is required [3]
 fls		r6,		r6
 asl		r6,		r6,		3
 subl	r13,	r13,	r6
 
-; Compensate writeback
+; Compensate writeback in the loop break
+; Should be 8 byte compensation, but if we only compensate 4 bytes we can
+; fallthrough to 4 byte reread
 subl	r13,	r13,	4
+
 .L_reread_last_4bytes:
 subl	r13,	r13,	4
 
-;; 1 byte search until NULL byte is found
+; Perform 1 byte search until NULL byte is found
 ldb		r10,	[r13]
-.L_search_next_1byte_chunk:
-	cmp		r10,	0
-	bne.d	@.L_search_next_1byte_chunk
-	ldb.aw	r10,	[r13, +1]
+.L_search_next_1byte_chunk_dest:
+		cmp		r10,	0
+		bne.d	@.L_search_next_1byte_chunk_dest
+		ldb.aw	r10,	[r13, +1]
 
 ; NULL byte was found in r0 - 1
 .L_string_end_found:
-	subl	r13,	r13,		1
-
+subl	r13,	r13,		1
 
 ; ========================== STRLEN CODE END >|< ==========================
 
-	; Compare address alignments
-	bmsk.f		r10,		r13,		2
-	bmsk.f		r11,		r1,		    2
-	SUB.f		r10,		r10,	    r11
+; Compare address alignments
+bmsk.f	r10,		r13,		2
+bmsk.f	r11,		r1,		    2
+SUB.f	r10,		r10,	    r11
 
-	; If alignments are different, will never match alignment
-	bne		@.L_start_1byte_search_src
+; If alignments are different, will never match alignment
+bne		@.L_start_1byte_search_src
 
-    ; Aligned at 4 byte!
-	bmsk.f	r3,		r13,		1
-	beq.d			@.L_start_4byte_search_src
+; If address is 4 byte aligned, we can just directly read 4 bytes
+bmsk.f	r3,		r13,		1
+beq.d			@.L_4B_step_src
 
-	subl	r3,		r3,		1		; [0]
-	asl		r3,		r3,		2		; [1]
+subl	r3,		r3,		1		; [0]
+asl		r3,		r3,		2		; [1]
 
-	; r3 now represents the inverse of the amount of instructions to skip
-	bi	    [r3]
+; Jump depending on the alignment
+bi	    [r3]
 ; Read 3 bytes
-	ldb.ab	r10,	[r1,	+1]
-	cmp		r10,	0
-	beq.d			@.L_return_ptr
-    stb.ab	r10,	[r13,	+1]
+ldb.ab	r10,	[r1,	+1]
+cmp		r10,	0
+beq.d			@.L_return_dest
+stb.ab	r10,	[r13,	+1]
+
 ; Read 2 bytes
-	ldb.ab	r10,	[r1,	+1]
-	cmp		r10,	0
-	beq.d			@.L_return_ptr
-    stb.ab	r10,	[r13,	+1]
+ldb.ab	r10,	[r1,	+1]
+cmp		r10,	0
+beq.d			@.L_return_dest
+stb.ab	r10,	[r13,	+1]
+
 ; Read 1 byte
-	ldb.ab	r10,	[r1,	+1]
-	cmp		r10,	0
-	beq.d			@.L_return_ptr
-    stb.ab	r10,	[r13,	+1]
+ldb.ab	r10,	[r1,	+1]
+cmp		r10,	0
+beq.d			@.L_return_dest
+stb.ab	r10,	[r13,	+1]
 
 
-; r13 is now either 4 or 8 byte aligned
-.L_start_4byte_search_src:
+; By this point, r13 and r1 are either 4 or 8 byte aligned, with
+; matching alignments
+.L_4B_step_src:
 
 ; If aligned to 8 bytes, just jump ahead
-	andl.f	0,		r1,		0b111
-	beq.d	@.L_search_32bytes_src
-	xorl	r6,		r6,		r6	; reset mask showing NULL byte location
+andl.f	0,		r1,		0b111
+beq.d			@.L_4_8B_search_src
+; Always reset bit mask that will encode NULL byte location
+xorl	r6,		r6,		r6
 
-	ld.ab	r10,	[r1,	+4]
-	sub		r11,	r10,	NULL_32DT_1
-	bic		r11,	r11,	r10
-	tst		r11,	NULL_32DT_2
-	bne		@.L_reread_last_4bytes_src
+ld.ab	r10,	[r1,	+4]
+sub		r11,	r10,	NULL_32DT_1
+bic		r11,	r11,	r10
+tst		r11,	NULL_32DT_2
+bne				@.L_reread_last_4bytes_src
 
-	stl.ab	r10,	[r13,	+4]
+; NULL byte detector is already setup by strlen
 
-.L_search_32bytes_src:
-	ldl.ab	r2,	[r1,	+8]
-	ldl.ab	r3,	[r1,	+8]
-	ldl.ab	r4,	[r1,	+8]
-	ldl.ab	r5,	[r1,	+8]
+stl.ab	r10,	[r13,	+4]
 
-; If there is a 0 in any of the read 32 bytes, its location is encoded
-; in r6 as a bit mask
-; This bitmask can be used to calculate the appropriate regression in the pointer [3]
-	subl	r10,	r2,		r8
-	subl	r11,	r3,		r8
-	subl	r12,	r4,		r8
-	subl	r7,		r5,		r8
+.L_4_8B_search_src:
+		ldl.ab	r2,		[r1,	+8]
+		ldl.ab	r3,		[r1,	+8]
+		ldl.ab	r4,		[r1,	+8]
+		ldl.ab	r5,		[r1,	+8]
 
-	bicl	r10,	r10,	r2
-	bicl	r11,	r11,	r3
-	bicl	r12,	r12,	r4
-	bicl	r7,		r7,		r5
+		; NULL byte position is detected and encoded in r6 [4] [5]
+		subl	r10,	r2,		r8
+		subl	r11,	r3,		r8
+		subl	r12,	r4,		r8
+		subl	r7,		r5,		r8
 
-	tstl		r10,	r9
-	bset.ne		r6,		r6,		4
+		bicl	r10,	r10,	r2
+		bicl	r11,	r11,	r3
+		bicl	r12,	r12,	r4
+		bicl	r7,		r7,		r5
 
-	tstl		r11,	r9
-	bset.ne		r6,		r6,		3
+		tstl	r10,	r9
+		bset.ne	r6,		r6,		4
 
-	tstl		r12,	r9
-	bset.ne		r6,		r6,		2
+		tstl	r11,	r9
+		bset.ne	r6,		r6,		3
 
-	tstl		r7,		r9
-	bset.ne		r6,		r6,		1
+		tstl	r12,	r9
+		bset.ne	r6,		r6,		2
 
-	brne	r6,		0,		@.L_found_in_32B
+		tstl	r7,		r9
+		bset.ne	r6,		r6,		1
 
-	stl.ab	r2,	[r13,	+8]
-	stl.ab	r3,	[r13,	+8]
-	stl.ab	r4,	[r13,	+8]
-	stl.ab	r5,	[r13,	+8]
+		brne	r6,		0,		@.L_found_in_32B
 
-	j @.L_search_32bytes_src
+		stl.ab	r2,	[r13,	+8]
+		stl.ab	r3,	[r13,	+8]
+		stl.ab	r4,	[r13,	+8]
+		stl.ab	r5,	[r13,	+8]
+
+		j 		@.L_4_8B_search_src
 
 .L_found_in_32B:
 
-; Back track only what is required [4]
-;fls		r6,		r6
+; Back track only what is required [5]
+fls		r6,		r6
 
-;bi		[r6]
-;stl.ab	r5,	[r13,	+8]
-;stl.ab	r4,	[r13,	+8]
-;stl.ab	r3,	[r13,	+8]
-;stl.ab	r2,	[r13,	+8]
+asl		r5,		r6,		3
+sub		r6,		r6,		1
 
-;asl		r6,		r6,		3
-;subl	r1,		r1,		r6
+subl	r1,		r1,		r5
+asl		r6,		r6,		2
 
-; Compensate writeback
-;addl	r1,	r1,	4
+bi		[r6]
+stl.ab	r2,		[r13,	+8]
+stl.ab	r3,		[r13,	+8]
+stl.ab	r4,		[r13,	+8]
+b				@.L_start_1byte_search_src
 
-subl	r1,		r1,		28
+stl.ab	r2,		[r13,	+8]
+stl.ab	r3,		[r13,	+8]
+b				@.L_start_1byte_search_src
+nop
+
+stl.ab	r2,		[r13,	+8]
+nop
+nop
+nop
+
+; Passthrough to last branch
+
+b		@.L_start_1byte_search_src
 
 .L_reread_last_4bytes_src:
 
 subl	r1,     r1,     4
 
+; Perform 1 byte search until NULL byte is found
 .L_start_1byte_search_src:
 
-	; Look for NULL byte
-	ldb.ab	r11,	[r1, +1]
-	cmp		r11,	0
+		; Look for NULL byte
+		ldb.ab	r11,	[r1, 	+1]
+		cmp		r11,	0
 
-    bne.d   @.L_start_1byte_search_src
-	stb.ab	r11,	[r13, +1]
+		bne.d   		@.L_start_1byte_search_src
+		stb.ab	r11,	[r13, 	+1]
 
-.L_return_ptr:
-	j_s	[blink]
+.L_return_dest:
+j_s	[blink]
 
 
 ENDFUNC (strcat)
+
+
+;; The first step in this code is to "fix" the address alignment
+;
+;; First, we check if the address is already 4 byte aligned.
+;; If so, we can simply read 4 bytes and start the 8 byte reads
+;
+;; Otherwise, we can look at the last 2 bits in the address, and infer
+;; how many 1 byte loads are required
+; The following table shows how the last two bytes correlate to branch index
+; and how many bytes we need to read
+;
+;   (b1,b0) | bytes to search |  branch index  | required jump
+; ----------+-----------------+----------------+--------------
+;   00b (0) |   <---  Already aligned, jumps directly to 4 byte search
+;   01b (1) |        3        |        0       |   0
+;   10b (2) |        2        |        1       |   4
+;   11b (3) |        1        |        2       |   8
+;
+; Removing 1 from b1b0 [0] gives us the "branch index".
+; Now to get the appropriate jump size (how many instructions there are per
+; branch) we can just multiply by 4 [1]
+; The nops could be removed by having r3 be multiples of 3*8 but the extra
+; operation isnt worth it
+;
+;; This code uses a common technique for NULL byte detection inside a word.
+;; Details on this technique can be found in:
+;; (https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord)
+;
+; In sum, this technique allows for detecting a NULL byte inside any given 
+; amount of bits by performing the following operation
+; 		DETECTNULL(X) (((X) - 0x01010101) & ~(X) & 0x80808080)
+;
+; The code above implements this by setting r8 to 0x01010101 and r9 to
+; 0x80808080
+; This operation differs slightly between 64 bit and 32 bit analysis.
+; As LIMM are 32 bit only, we need to perform MOVHL and ORL [2] operations to
+; have the appropriate 64 bit values in place
+;
+;; The major optimization in this code is to perform several 8 load byte loads
+;; in a row and using the previously mentioned NULL byte detection method to
+;; find the end of the string
+;
+; To achieve this, finding a NULL byte sets a bitmask that [3], when passed via
+; the "find last set" instruction returns the amount of 8 byte chunks to
+; backtrack. We can then simply multiply by 8 and remove that value from the
+; pointer to make it point to the 8 byte chunk containing the NULL byte.
+; We can then perform a simple byte search to find it.
+; One possible optimization is to not perform a final 1 byte search, but use
+; the already loaded registers to, depending on endianness, find the position
+; of the NULL byte and appropriately adjust the pointer for size calculation
+;
+; The order the NULL byte detection operations are performed in isnt random [4]
+; They are ordered in order to reduce register dependency and allow the CPU to
+; run them in parallel
+;
+;; When the src NULL byte is found, the encoded position is used to perform the
+;; appropriate stores, and reset pointers such that 1 byte search can be
+;; performed optimally, and not waste the contents already loaded [5]
+;
+; The operation is a lot like what is done for alignment
+; We must backtrack r1 appropriately. If we dont always retreat 32 bytes, we
+; must store the already loaded 8 byte chunks present in r2, r3, r4 (r5 is 
+; never loaded because if the target byte was found, at the very least it
+; is in r5, which needs to be re-searched.
+;
+;    r6 bit | bytes to backtrack | Registers to store |
+; ----------+--------------------+----------+---------|
+;   01b (1) |          8         |      r2, r3, r4    |
+;   10b (2) |          16        |        r2, r3      |
+;  100b (3) |          24        |          r2        |
+; 1000b (4) |          32        |         none       |
+;
+; To set r1, we multipply r6 by 8 and we can use that to reduce r1
+; appropriately
+; To set r13, and not waste the loaded contents, we can subtract 1 from r6
+; and then multiply it by 4 to obtain the appropriate instructions to run
+; 
+; The nops are very important to keep the alignment of the jump
+;
+;
+
 
 #endif

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -252,59 +252,34 @@ fls	r6, r6 ; [2]
 	MOVP	r10, r7
 	MOVP	r11, r5
 
-; r10 contains 
-; r11 contains the last 64 bits to potentially write
 
 ; Point r13 to first NULL byte in selected double word
 .L_fix_r1:
 	andl	r10, r10, r9 ; [5]
-; R10 now has only the highest bit in each byte set, for NULL bytes.
-; So, we find the rightmost bit, which will belong to the first NULL byte, counting from the right.
-; r10 will be 0 to 7
 
 	ffsl	r12, r10 ; [6]
-
 	addl	r12, r12, 1 ; [6]
-
 	xbful 	r12, r12, 0b00111000011 ; [7]
 
-; r12 now contains which byte the last NULL byte is
-; If r12 is 0, the NULL byte is the last one and we need to copy 7 bytes,
-; if it is 7, we need to copy 0 bytes
-
-;ldl.ab	r2, [r13, +8]
-
-; How many bytes to copy is in r10 now
-
+	; 
 	subl	r12, 8, r12
+	asl		r12, r12, 3
 
-	asl		r12, r12, 1
+	movl	r10, 0xffffffffffffffff
 
-	bi [r12]
+	lsrl	r10, r10, r12
 
-	stb.ab	r11, [r13, +1]
-	lsrl	r11, r11, 8
+	notl	r9, r10
 
-	stb.ab	r11, [r13, +1]
-	lsrl	r11, r11, 8
+	ldl	r2, [r13]
 
-	stb.ab	r11, [r13, +1]
-	lsrl	r11, r11, 8
+	andl	r3, r10, r11
 
-	stb.ab	r11, [r13, +1]
-	lsrl	r11, r11, 8
+	andl	r4, r9, r2
 
-	stb.ab	r11, [r13, +1]
-	lsrl	r11, r11, 8
-
-	stb.ab	r11, [r13, +1]
-	lsrl	r11, r11, 8
-
-	stb.ab	r11, [r13, +1]
-	lsrl	r11, r11, 8
-
-	stb.ab	r11, [r13, +1]
-	nop
+	orl		r3, r3, r4
+	
+	stl.ab	r3, [r13, +8]
 
 	j_s.d	[blink]
 

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -259,38 +259,40 @@ ENTRY (strcat)
 	MOVP	r10, r7
 	MOVP	r11, r5
 
-
+; r11 now contains the data to write
+; r10 contains most of the NULL byte detector operation
 .L_store_lastL64bits:
 
 	andl	r10, r10, r9 ; [5]
 
-	ffsl	r12, r10 ; [6]
-	addl	r12, r12, 1
+	ffsl	r2, r10 ; [6]
+	addl	r2, r2, 1
 
-	xbful 	r12, r12, 0b00111000011 ; [7]
+	xbful 	r2, r2, 0b00111000011 ; [7]
+
+	movl	r3, 0xffffffffffffffff	; Bitmask setup
 
 	; If the NULL byte is in byte 3 (starting from the right)
 	; we want to store 8-3 bytes
-	subl	r12, 8, r12
-	asl		r12, r12, 3
+	subl	r2, 8, r2
+	asl		r2, r2, 3
 
 	; According to the target byte, setup masks
-	movl	r10, 0xffffffffffffffff
-	lsrl	r10, r10, r12
-	notl	r9, r10
-
+	lsrl	r3, r3, r2
+	notl	r4, r3
 
 	; Obtain relevant data from destination
-	ldl	r2, [r13]
-	; Get which data from dest is not to be overwritten and or it
+	ldl	r10, [r13]
+
+	; Get which data from dest is not to be overwritten and OR it
 	; with the relevant data to write
-	andl	r3, r10, r11
-	andl	r4, r9, r2
+	andl	r3, r3, r11
+	andl	r4, r4, r10
 
 	orl		r3, r3, r4
 
 	stl.ab	r3, [r13, +8]
-	
+
 	j_s.d	[blink]
 
 

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -62,7 +62,7 @@ ENTRY (strcat)
 	movl	r13, r0
 	xorl	r6, r6, r6
 
-; Setup byte detector (more information bellow) [1]
+; Setup byte detector (more information below) [1]
 	vpack2wl	r8, NULL_32DT_1, NULL_32DT_1
 	asll	r9, r8, 7
 
@@ -165,7 +165,7 @@ ENTRY (strcat)
 	# error Unknown configuration
 #endif
 
-; NULL byte position is detected and encoded in r6 [4] [5]
+; NULL byte position is detected and encoded in r6 [0] [9]
 	subl	r10, r2, r8
 	subl	r11, r3, r8
 	subl	r12, r4, r8
@@ -208,20 +208,27 @@ ENTRY (strcat)
 # error Unknown configuration
 #endif
 
-j 		@.L_4_8B_search_src
+	j	@.L_4_8B_search_src
 
 .L_found_in_32B:
 
-fls	r6, r6 ; [2]
+	fls	r6, r6 ; [2]
 
-; Point r13 to first NULL byte containing double word [3]
+; Point r1 to first NULL byte containing double word [3]
 	sub3l	r1, r1, r6
 
-; Select appropriate register to analyze [4]
-	subl	r6, r6, 1
+;; Store the already loaded data
+
+	; 4 -> 1 to 3 -> 0
+	;subl	r6, r6, 1
+
 ; Invert so the biggest branch is at the end, and we dont need to increase
 ; block size
-	subl	r6, 3, r6
+	; 3 -> 0 to 0 -> 3
+	;subl	r6, 3, r6
+
+	; Condense the two subs here
+	subl	r6, 4, r6
 
 	mpyl	r6, r6, 5
 
@@ -230,21 +237,21 @@ fls	r6, r6 ; [2]
 
 	MOVP	r10, r10
 	MOVP	r11, r2
-	b	@.L_fix_r1
+	b	@.L_store_lastL64bits
 	nop
 	nop
 
 	stl.ab	r2, [r13, +8]
 	MOVP	r10, r11
 	MOVP	r11, r3
-	b	@.L_fix_r1
+	b	@.L_store_lastL64bits
 	nop
 
 	stl.ab	r2, [r13, +8]
 	stl.ab	r3, [r13, +8]
 	MOVP	r10, r12
 	MOVP	r11, r4
-	b	@.L_fix_r1
+	b	@.L_store_lastL64bits
 
 	stl.ab	r2, [r13, +8]
 	stl.ab	r3, [r13, +8]
@@ -253,116 +260,112 @@ fls	r6, r6 ; [2]
 	MOVP	r11, r5
 
 
-; Point r13 to first NULL byte in selected double word
-.L_fix_r1:
+.L_store_lastL64bits:
+
 	andl	r10, r10, r9 ; [5]
 
 	ffsl	r12, r10 ; [6]
-	addl	r12, r12, 1 ; [6]
+	addl	r12, r12, 1
+
 	xbful 	r12, r12, 0b00111000011 ; [7]
 
-	; 
+	; If the NULL byte is in byte 3 (starting from the right)
+	; we want to store 8-3 bytes
 	subl	r12, 8, r12
 	asl		r12, r12, 3
 
+	; According to the target byte, setup masks
 	movl	r10, 0xffffffffffffffff
-
 	lsrl	r10, r10, r12
-
 	notl	r9, r10
 
+
+	; Obtain relevant data from destination
 	ldl	r2, [r13]
-
+	; Get which data from dest is not to be overwritten and or it
+	; with the relevant data to write
 	andl	r3, r10, r11
-
 	andl	r4, r9, r2
 
 	orl		r3, r3, r4
-	
-	stl.ab	r3, [r13, +8]
 
+	stl.ab	r3, [r13, +8]
+	
 	j_s.d	[blink]
 
 
 ENDFUNC (strcat)
 
 
-;; The first step in this code is to "fix" the address alignment
-;
-;; First, we check if the address is already 4 byte aligned.
-;; If so, we can simply read 4 bytes and start the 8 byte reads
-;
-;; Otherwise, we can look at the last 2 bits in the address, and infer
-;; how many 1 byte loads are required
-; The following table shows how the last two bytes correlate to branch index
-; and how many bytes we need to read
-;
-;   (b1,b0) | bytes to search |  branch index  | required jump
-; ----------+-----------------+----------------+--------------
-;   00b (0) |   <---  Already aligned, jumps directly to 4 byte search
-;   01b (1) |        3        |        0       |   0
-;   10b (2) |        2        |        1       |   4
-;   11b (3) |        1        |        2       |   8
-;
-; Removing 1 from b1b0 [0] gives us the "branch index".
-; Now to get the appropriate jump size (how many instructions there are per
-; branch) we can just multiply by 4 [1]
-; The nops could be removed by having r3 be multiples of 3*8 but the extra
-; operation isnt worth it
-;
 ;; This code uses a common technique for NULL byte detection inside a word.
 ;; Details on this technique can be found in:
 ;; (https://graphics.stanford.edu/~seander/bithacks.html#ZeroInWord)
 ;
 ; In sum, this technique allows for detecting a NULL byte inside any given 
 ; amount of bits by performing the following operation
-; 		DETECTNULL(X) (((X) - 0x01010101) & ~(X) & 0x80808080)
+; 		DETECTNULL(X) (((X) - 0x01010101) & ~(X) & 0x80808080) [0]
 ;
-; The code above implements this by setting r8 to 0x01010101 and r9 to
-; 0x80808080
-; This operation differs slightly between 64 bit and 32 bit analysis.
-; As LIMM are 32 bit only, we need to perform MOVHL and ORL [2] operations to
+; The code above implements this by setting r8 to a 0x01010101... sequence and
+; r9 to a 0x80808080... sequence of appropriate length
+; As LIMM are 32 bit only, we need to perform MOVHL and ORL [1] operations to
 ; have the appropriate 64 bit values in place
 ;
-;; The major optimization in this code is to perform several 8 load byte loads
-;; in a row and using the previously mentioned NULL byte detection method to
-;; find the end of the string
+;; Search is done 32 bytes at a time, either with 64 bit loads or 128 bit loads
+;; If a NULL byte is detected, the position of the double word is encoded
+;; in r6, which is then used to adjust r13 to the exact byte
 ;
-; To achieve this, finding a NULL byte sets a bitmask that [3], when passed via
-; the "find last set" instruction returns the amount of 8 byte chunks to
-; backtrack. We can then simply multiply by 8 and remove that value from the
-; pointer to make it point to the 8 byte chunk containing the NULL byte.
-; We can then perform a simple byte search to find it.
-; One possible optimization is to not perform a final 1 byte search, but use
-; the already loaded registers to, depending on endianness, find the position
-; of the NULL byte and appropriately adjust the pointer for size calculation
-;
-; The order the NULL byte detection operations are performed in isnt random [4]
-; They are ordered in order to reduce register dependency and allow the CPU to
-; run them in parallel
-;
-;; When the src NULL byte is found, the encoded position is used to perform the
-;; appropriate stores, and reset pointers such that 1 byte search can be
-;; performed optimally, and not waste the contents already loaded [5]
-;
-; The operation is a lot like what is done for alignment
-; We must backtrack r1 appropriately. If we dont always retreat 32 bytes, we
-; must store the already loaded 8 byte chunks present in r2, r3, r4 (r5 is 
-; never loaded because if the target byte was found, at the very least it
-; is in r5, which needs to be re-searched.
-;
-;    r6 bit | bytes to backtrack | Registers to store |
-; ----------+--------------------+----------+---------|
-;   01b (1) |          8         |      r2, r3, r4    |
-;   10b (2) |          16        |        r2, r3      |
-;  100b (3) |          24        |          r2        |
-; 1000b (4) |          32        |         none       |
-;
-; To set r1, we multipply r6 by 8 and we can use that to reduce r1
-; appropriately
-; To set r13, and not waste the loaded contents, we can subtract 1 from r6
-; and then multiply it by 4 to obtain the appropriate instructions to run
+; r6 is set via bset, which means we can simply use a fls to obtain the first
+; match (or ffs depending on the values in bset) [2].
+; The reason for starting at 1 and not 0 is so r6 encodes how many double
+; words to go back, and it wouldnt make sense to go back 0 (the NULL would be
+; in the next loop iteration).
 ; 
-; The nops are very important to keep the alignment of the jump
-;
+; The first step to take is point r13 to the appropriate double word.
+; As the chosen encoded information is how many double words to go back,
+; we can simply multiply r6 by 8 and reduce r13 by that amount [3]
+; 
+; Then, we need to place the loaded double word containing the first NULL byte
+; into a "common" register we can operate on later [4].
+; 
+; To do this without any jumps, we can shift r6 and perform a conditional mov
+; based on the carry flag value.
+; The order is very important because the NULL byte can appear in several
+; double words, so we want to analyze from last to first.
+; 
+; We can ignore the first asr (which would be asr.f 2, as we started r6 on 1)
+; because if r7 isnt the NULL byte, r2 will always be overwritten so we can
+; just decide to start at r7, and overwrite it if needed.
+; 
+; Now comes the tricky part. In order to obtain the first NULL byte, we need to
+; understand the NULL byte detection operation. It is explained in depth in the
+; link above but in short, it works by first setting the highest bit of each
+; byte to 1, if the corresponding byte is either 0 or less than 0x80
+; Then, separately, it makes the highest bit of each byte 1, if the byte is
+; less than 0x80. The last step is to and these two values (this operation is
+; simplified with the subl, bicl and tst instructions).
+; 
+; This means that the evaluated equation result value [5] has zeros for all non
+; zero bytes, except for the NULL bytes. Therefore, we can simply find the
+; first non zero bit (counting from bit 0) which will be inside the position of
+; the first NULL byte.
+; 
+; One thing to note, is that ffs oddly returns 31 if no bit is found, setting
+; the zero flag. As r9 is never all 0s at this stage (would mean there is no 
+; NULL byte and we wouldnt be here) we dont need to worry about that. [6]
+; 
+; We can then convert the bit position into the last byte position by looking
+; into bits 3 to 6, and shifting 3 bits to the right. This can be combined into
+; a single xbful operation. The bottom 000011 represent shift by 3 and the top
+; 01111 represents the mask (3 to 6 shifted by 3 is 0 to 3) [7]
+; 
+; Finally, we can add the NULL byte position inside the loaded double word to
+; r13 and subtract r0 from r13 to obtain the string size [8]
+; 
+; Some operations are re-ordered such that register dependency is reduced,
+; allowing the CPU to run more instructions in parallel [9]
+; 
+; 
+; Some data was already read, and needs to be stored following the same read
+; order. To do this, we need to make the 
+; 
 ;

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -39,7 +39,10 @@
 ENTRY (strcat)
 ; Find end of r0
 ; ========================== STRLEN CODE START ==========================
-
+	;; Setup byte detector (more information bellow)
+	mov		r8,		0x01010101
+	ror		r9,		r8
+    
 	; address is 4 byte aligned, go to 4 byte search
 	bmsk.f	r3,		r0,		1
 	beq.d			@.L_start_4byte_search
@@ -67,9 +70,6 @@ ENTRY (strcat)
 	SUBP	r2,		r2,		1
 
 .L_start_4byte_search:
-	;; Setup byte detector (more information bellow)
-	mov		r8,		0x01010101
-	ror		r9,		r8
 
 	; Load next 4 bytes
 	ld.ab	r10,	[r13, +4]
@@ -91,9 +91,8 @@ ENTRY (strcat)
 ; Backtrack 8 bytes [2]
 ; 4 because of write-back, 4 because we dont know for sure where in the
 ; 4 bytes the NULL byte is. Then perform 1 byte search
-	SUBP	r13,		r13,		8
-
-	ldb		r10,	[r13]
+SUBP	r13,		r13,		8
+ldb		r10,	[r13]
 
 ;; 1 byte search until NULL byte is found
 .L_search_next_1byte_chunk:
@@ -107,15 +106,47 @@ ENTRY (strcat)
 
 ; ========================== STRLEN CODE END >|< ==========================
 
-.L_search_next_1byte_chunk_src:
+	; Compare address alignments
+	bmsk.f		r10,		r13,		2
+	bmsk.f		r11,		r1,		    2
+	SUB.f		r10,		r10,	    r11
 
-	ldb.ab	r11,	[r1, +1]
+	; If alignments are different, will never match alignment
+	bne		@.L_start_1byte_search
+
+ld.ab	r11,	[r1, +4]
+sub		r12, r11, r8
+bic		r12, r12, r11
+tst		r12, r9
+bne.d	@.L_start_search_next_1byte_chunk
+
+.L_copy_4byte_chunk:
+	; Set r10 to be the previously read 4 bytes
+    ; Move known non NULL containing bytes to r10
+	MOVP	r10,    r11
+	; Read next 4 bytes
+	ld.ab	r11,	[r1, +4]
+	; Check if NULL byte is in the next 4 bytes
+	sub		r12,    r11,    r8
+	bic		r12,    r12,    r11
+	tst		r12,    r9
+
+	; NULL byte not found, store previous non-NULL byte containing bytes and continue
+	beq.d	@.L_copy_4byte_chunk
+	st.ab	r10,	[r13, +4]
+
+.L_start_search_next_1byte_chunk:
+
+SUBP	r1,     r1,     4
+
+.L_start_1byte_search:
+
 	; Look for NULL byte
+	ldb.ab	r11,	[r1, +1]
 	cmp		r11,	0
-	beq.d	@.L_return_ptr
 
+    bne.d   @.L_start_1byte_search
 	stb.ab	r11,	[r13, +1]
-	j		@.L_search_next_1byte_chunk_src
 
 .L_return_ptr:
 	j_s	[blink]

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -55,7 +55,6 @@
 
 #if defined (__ARC64_ARCH32__)
 
-
 ENTRY (strcat)
 ; Find end of r0 string
 ; ========================== STRLEN CODE START ==========================
@@ -67,7 +66,6 @@ ENTRY (strcat)
 ; Setup byte detector (more information below) [1]
 	mov	r8, NULL_32DT_1
 	asl	r9, r8, 7
-
 
 .L_4_4B_search:
 
@@ -196,7 +194,7 @@ ENTRY (strcat)
 
 #endif
 
-	j	@.L_4_4B_search_src
+	b	@.L_4_4B_search_src
 
 .L_found_in_32B:
 
@@ -216,27 +214,27 @@ ENTRY (strcat)
 	;subl	r6, 3, r6
 
 	; Condense the two subs here
-	sub	r6, 4, r6
+	rsub	r6, r6, 4
 
 	asl	r6, r6, 2
 
 ; Store double words
 	bi	[r6]
 
+	b.d	@.L_store_lastL32bits
 	mov	r11, r2
-	b	@.L_store_lastL32bits
 	nop
 	nop
 
 	st.ab	r2, [r13, +4]
+	b.d	@.L_store_lastL32bits
 	mov	r11, r3
-	b	@.L_store_lastL32bits
 	nop
 
 	st.ab	r2, [r13, +4]
 	st.ab	r3, [r13, +4]
+	b.d	@.L_store_lastL32bits
 	mov	r11, r4
-	b	@.L_store_lastL32bits
 
 	st.ab	r2, [r13, +4]
 	st.ab	r3, [r13, +4]
@@ -258,7 +256,7 @@ ENTRY (strcat)
 
 	; If the NULL byte is in byte 3 (starting from the right)
 	; we want to store 8-3 bytes
-	sub	r2, 8, r2
+	rsub	r2, r2, 8
 	asl	r2, r2, 3
 
 	; According to the target byte, setup masks
@@ -275,20 +273,18 @@ ENTRY (strcat)
 
 	or	r3, r3, r4
 
+	j_s.d	[blink]
 	st.ab	r3, [r13, +4]
 
-	j_s.d	[blink]
 
 
 ENDFUNC (strcat)
-
 
 #else
 
 ENTRY (strcat)
 ; Find end of r0 string
 ; ========================== STRLEN CODE START ==========================
-
 
 ; Preserve r0 for size calculation when returning
 	movl	r13, r0
@@ -297,7 +293,6 @@ ENTRY (strcat)
 ; Setup byte detector (more information below) [1]
 	vpack2wl	r8, NULL_32DT_1, NULL_32DT_1
 	asll	r9, r8, 7
-
 
 .L_4_8B_search:
 
@@ -362,7 +357,6 @@ ENTRY (strcat)
 	MOVP.c	r2, r10
 
 ; Point r13 to first NULL byte in selected double word
-.L_fix_r13:
 	andl	r2, r2, r9 ; [5]
 
 	ffsl	r2, r2 ; [6]
@@ -434,7 +428,7 @@ ENTRY (strcat)
 # error Unknown configuration
 #endif
 
-	j	@.L_4_8B_search_src
+	b	@.L_4_8B_search_src
 
 .L_found_in_32B:
 
@@ -454,27 +448,27 @@ ENTRY (strcat)
 	;subl	r6, 3, r6
 
 	; Condense the two subs here
-	subl	r6, 4, r6
+	rsubl	r6, r6, 4
 
 	asll	r6, r6, 2
 
 ; Store double words
 	bi	[r6]
 
+	b.d	@.L_store_lastL64bits
 	MOVP	r11, r2
-	b	@.L_store_lastL64bits
 	nop
 	nop
 
 	stl.ab	r2, [r13, +8]
+	b.d	@.L_store_lastL64bits
 	MOVP	r11, r3
-	b	@.L_store_lastL64bits
 	nop
 
 	stl.ab	r2, [r13, +8]
 	stl.ab	r3, [r13, +8]
+	b.d	@.L_store_lastL64bits
 	MOVP	r11, r4
-	b	@.L_store_lastL64bits
 
 	stl.ab	r2, [r13, +8]
 	stl.ab	r3, [r13, +8]
@@ -497,8 +491,8 @@ ENTRY (strcat)
 
 	; If the NULL byte is in byte 3 (starting from the right)
 	; we want to store 8-3 bytes
-	subl	r2, 8, r2
-	asl		r2, r2, 3
+	rsubl	r2, r2, 8
+	asl	r2, r2, 3
 
 	; According to the target byte, setup masks
 	lsrl	r3, r3, r2
@@ -512,11 +506,10 @@ ENTRY (strcat)
 	andl	r3, r3, r11
 	andl	r4, r4, r10
 
-	orl		r3, r3, r4
-
-	stl.ab	r3, [r13, +8]
+	orl	r3, r3, r4
 
 	j_s.d	[blink]
+	stl.ab	r3, [r13, +8]
 
 
 ENDFUNC (strcat)

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -53,6 +53,218 @@
 ;		- char* (destiantion string)
 ;
 
+#if defined (__ARC64_ARCH32__)
+
+
+ENTRY (strcat)
+; Find end of r0 string
+; ========================== STRLEN CODE START ==========================
+
+; Preserve r0 for size calculation when returning
+	mov	r13, r0
+	xor	r6, r6, r6
+
+; Setup byte detector (more information below) [1]
+	mov	r8, NULL_32DT_1
+	asl	r9, r8, 7
+
+
+.L_4_4B_search:
+
+	ld.ab	r2, [r13, +4]
+	ld.ab	r3, [r13, +4]
+	ld.ab	r4, [r13, +4]
+	ld.ab	r5, [r13, +4]
+
+; NULL byte position is detected and encoded in r6 [0] [9]
+	sub	r10, r2, r8
+	sub	r11, r3, r8
+	sub	r12, r4, r8
+	sub	r7, r5, r8
+
+	bic	r10, r10, r2
+	bic	r11, r11, r3
+	bic	r12, r12, r4
+	bic	r7, r7, r5
+
+	tst	r10, r9
+	bset.ne	r6, r6, 4
+
+	tst	r11, r9
+	bset.ne	r6, r6, 3
+
+	tst	r12, r9
+	bset.ne	r6, r6, 2
+
+	tst	r7, r9
+	bset.ne	r6, r6, 1
+
+	breq.d	r6, 0, @.L_4_4B_search
+
+	fls	r6, r6 ; [2]
+
+; Point r13 to first NULL byte containing double word [3]
+	sub2	r13, r13, r6
+
+; Select appropriate register to analyze [4]
+	sub	r6, r6, 1
+	asl r6, r6, 1
+
+	bi	[r6]
+	mov	r2, r7
+	b	@.L_fix_r13
+	mov	r2, r12
+	b	@.L_fix_r13
+	mov	r2, r11
+	b	@.L_fix_r13
+	mov	r2, r10
+	nop
+
+; Point r13 to first NULL byte in selected double word
+.L_fix_r13:
+	and	r2, r2, r9 ; [5]
+
+	ffs	r2, r2 ; [6]
+
+	xbfu 	r2, r2, 0b0111000011 ; [7]
+
+	add	r13, r13, r2 ; [8]
+
+
+; ========================== STRLEN CODE END >|< ==========================
+
+	xor	r6, r6, r6
+
+.L_4_4B_search_src:
+
+	ld.ab	r2, [r1, +4]
+	ld.ab	r3, [r1, +4]
+	ld.ab	r4, [r1, +4]
+	ld.ab	r5, [r1, +4]
+
+; NULL byte position is detected and encoded in r6 [0] [9]
+	sub	r10, r2, r8
+	sub	r11, r3, r8
+	sub	r12, r4, r8
+	sub	r7, r5, r8
+
+	bic	r10, r10, r2
+	bic	r11, r11, r3
+	bic	r12, r12, r4
+	bic	r7, r7, r5
+
+	tst	r10, r9
+	bset.ne	r6, r6, 4
+
+	tst	r11, r9
+	bset.ne	r6, r6, 3
+
+	tst	r12, r9
+	bset.ne	r6, r6, 2
+
+	tst	r7, r9
+	bset.ne	r6, r6, 1
+
+	brne	r6, 0, @.L_found_in_32B
+
+	st.ab	r2, [r13, +4]
+	st.ab	r3, [r13, +4]
+	st.ab	r4, [r13, +4]
+	st.ab	r5, [r13, +4]
+
+	j	@.L_4_4B_search_src
+
+.L_found_in_32B:
+
+	fls	r6, r6 ; [2]
+
+; Point r1 to first NULL byte containing double word [3]
+	sub2	r1, r1, r6
+
+;; Store the already loaded data
+
+	; 4 -> 1 to 3 -> 0
+	;subl	r6, r6, 1
+
+; Invert so the biggest branch is at the end, and we dont need to increase
+; block size
+	; 3 -> 0 to 0 -> 3
+	;subl	r6, 3, r6
+
+	; Condense the two subs here
+	sub	r6, 4, r6
+
+	mpy	r6, r6, 5
+
+; Store double words
+	bi	[r6]
+
+	mov	r10, r10
+	mov	r11, r2
+	b	@.L_store_lastL32bits
+	nop
+	nop
+
+	st.ab	r2, [r13, +4]
+	mov	r10, r11
+	mov	r11, r3
+	b	@.L_store_lastL32bits
+	nop
+
+	st.ab	r2, [r13, +4]
+	st.ab	r3, [r13, +4]
+	mov	r10, r12
+	mov	r11, r4
+	b	@.L_store_lastL32bits
+
+	st.ab	r2, [r13, +4]
+	st.ab	r3, [r13, +4]
+	st.ab	r4, [r13, +4]
+	mov	r10, r7
+	mov	r11, r5
+
+; r11 now contains the data to write
+; r10 contains most of the NULL byte detector operation
+.L_store_lastL32bits:
+
+	and	r10, r10, r9 ; [5]
+
+	ffs	r2, r10 ; [6]
+	add	r2, r2, 1
+
+	xbfu 	r2, r2, 0b0111000011 ; [7]
+
+	mov	r3, 0xffffffffffffffff	; Bitmask setup
+
+	; If the NULL byte is in byte 3 (starting from the right)
+	; we want to store 8-3 bytes
+	sub	r2, 8, r2
+	asl		r2, r2, 3
+
+	; According to the target byte, setup masks
+	lsr	r3, r3, r2
+	not	r4, r3
+
+	; Obtain relevant data from destination
+	ld	r10, [r13]
+
+	; Get which data from dest is not to be overwritten and OR it
+	; with the relevant data to write
+	and	r3, r3, r11
+	and	r4, r4, r10
+
+	or		r3, r3, r4
+
+	st.ab	r3, [r13, +4]
+
+	j_s.d	[blink]
+
+
+ENDFUNC (strcat)
+
+
+#else
+
 ENTRY (strcat)
 ; Find end of r0 string
 ; ========================== STRLEN CODE START ==========================
@@ -298,6 +510,7 @@ ENTRY (strcat)
 
 ENDFUNC (strcat)
 
+#endif
 
 ;; This code uses a common technique for NULL byte detection inside a word.
 ;; Details on this technique can be found in:

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -1,5 +1,5 @@
 /*
-   Copyright (c) 2021, Synopsys, Inc. All rights reserved.
+   Copyright (c) 2022, Synopsys, Inc. All rights reserved.
 
    Redistribution and use in source and binary forms, with or without
    modification, are permitted provided that the following conditions are met:
@@ -53,264 +53,260 @@
 ;		- char* (destiantion string)
 ;
 
-#if defined (__ARC64_ARCH64__)
-
 ENTRY (strcat)
 ; Find end of r0 string
 ; ========================== STRLEN CODE START ==========================
 
-; If address is 4 byte aligned, we can just directly read 4 bytes
-bmsk.f	r3,		r0,		1
-beq.d			@.L_4B_step_dest
 
-; Store r0 for size calculation when returning
-MOVP	r13,	r0
+; Preserve r0 for size calculation when returning
+	movl	r13, r0
+	xorl	r6, r6, r6
 
-subl	r3,		r3,		1		; [0]
-asl		r3,		r3,		2		; [1]
+; Setup byte detector (more information bellow) [1]
+	vpack2wl	r8, NULL_32DT_1, NULL_32DT_1
+	asll	r9, r8, 7
 
-; Jump depending on the alignment.
-bi	    [r3]
-; Read 3 bytes
-ldb.ab	r10,	[r13,	+1]
-cmp		r10,	0
-beq 			@.L_string_end_found
-nop
-; Read 2 bytes
-ldb.ab	r10,	[r13,	+1]
-cmp		r10,	0
-beq				@.L_string_end_found
-nop
-; Read 1 byte
-ldb.ab	r10,	[r13,	+1]
-cmp		r10,	0
-beq				@.L_string_end_found
-nop
 
-; By this point, r13 is either 4 or 8 byte aligned
-.L_4B_step_dest:
+.L_4_8B_search:
 
-; If aligned to 8 bytes, just jump ahead
-andl.f	0,		r13,	0b111
-beq.d			@.L_start_4_8B_search_dest
+; Using 128-bit memory operations
+#if defined (__ARC64_M128__)
 
-; Always reset bit mask that will encode NULL byte location
-xorl	r6,		r6,		r6
+	lddl.ab r2r3, [r13, +16]
+	lddl.ab r4r5, [r13, +16]
 
-ld.ab	r10,	[r13,	+4]
-sub		r11,	r10,	NULL_32DT_1
-bic		r11,	r11,	r10
-tst		r11,	NULL_32DT_2
-bne				@.L_reread_last_4bytes
+; The 64-bit crunching implementation.
+#elif defined (__ARC64_ARCH64__)
 
-.L_start_4_8B_search_dest:
-; Setup byte detector (more information bellow) [2] [4]
-movhl	r8,		NULL_32DT_1
-movhl	r9,		NULL_32DT_2
+	ldl.ab	r2, [r13, +8]
+	ldl.ab	r3, [r13, +8]
+	ldl.ab	r4, [r13, +8]
+	ldl.ab	r5, [r13, +8]
 
-orl		r8,		r8,		NULL_32DT_1
-orl		r9,		r9,		NULL_32DT_2
+#else
+# error Unknown configuration
+#endif
 
-ldl.ab	r2,		[r13,	+8]
+; NULL byte position is detected and encoded in r6 [0] [9]
+	subl	r10, r2, r8
+	subl	r11, r3, r8
+	subl	r12, r4, r8
+	subl	r7, r5, r8
 
-.L_4_8B_search_dest:
-		ldl.ab	r3,		[r13,	+8]
-		ldl.ab	r4,		[r13,	+8]
-		ldl.ab	r5,		[r13,	+8]
+	bicl	r10, r10, r2
+	bicl	r11, r11, r3
+	bicl	r12, r12, r4
+	bicl	r7, r7, r5
 
-	; NULL byte position is detected and encoded in r6 [3] [4]
-		subl	r10,	r2,		r8
-		subl	r11,	r3,		r8
-		subl	r12,	r4,		r8
-		subl	r7,		r5,		r8
+	tstl	r10, r9
+	bset.ne	r6, r6, 4
 
-		bicl	r10,	r10,	r2
-		bicl	r11,	r11,	r3
-		bicl	r12,	r12,	r4
-		bicl	r7,		r7,		r5
+	tstl	r11, r9
+	bset.ne	r6, r6, 3
 
-		tstl		r10,	r9
-		bset.ne		r6,		r6,		4
+	tstl	r12, r9
+	bset.ne	r6, r6, 2
 
-		tstl		r11,	r9
-		bset.ne		r6,		r6,		3
+	tstl	r7, r9
+	bset.ne	r6, r6, 1
 
-		tstl		r12,	r9
-		bset.ne		r6,		r6,		2
+	breq.d	r6, 0, @.L_4_8B_search
 
-		tstl		r7,		r9
-		bset.ne		r6,		r6,		1
+	fls	r6, r6 ; [2]
 
-		breq.d		r6,		0,		@.L_4_8B_search_dest
-		ldl.ab		r2,		[r13,	+8]
+; Point r13 to first NULL byte containing double word [3]
+	sub3l	r13, r13, r6
 
-; Back track only what is required [3]
-fls		r6,		r6
-asl		r6,		r6,		3
-subl	r13,	r13,	r6
+; Select appropriate register to analyze [4]
+	subl	r6, r6, 1
+	asl r6, r6, 1
 
-; Compensate writeback in the loop break
-; Should be 8 byte compensation, but if we only compensate 4 bytes we can
-; fallthrough to 4 byte reread
-subl	r13,	r13,	4
+	bi	[r6]
+	MOVP	r2, r7
+	b	@.L_fix_r13
+	MOVP	r2, r12
+	b	@.L_fix_r13
+	MOVP	r2, r11
+	b	@.L_fix_r13
+	MOVP	r2, r10
+	nop
 
-.L_reread_last_4bytes:
-subl	r13,	r13,	4
+; Point r13 to first NULL byte in selected double word
+.L_fix_r13:
+	andl	r2, r2, r9 ; [5]
 
-; Perform 1 byte search until NULL byte is found
-ldb		r10,	[r13]
-.L_search_next_1byte_chunk_dest:
-		cmp		r10,	0
-		bne.d	@.L_search_next_1byte_chunk_dest
-		ldb.aw	r10,	[r13, +1]
+	ffsl	r2, r2 ; [6]
 
-; NULL byte was found in r0 - 1
-.L_string_end_found:
-subl	r13,	r13,		1
+	xbful 	r2, r2, 0b01111000011 ; [7]
+
+	addl	r13, r13, r2 ; [8]
+
 
 ; ========================== STRLEN CODE END >|< ==========================
 
-; Compare address alignments
-bmsk.f	r10,		r13,		2
-bmsk.f	r11,		r1,		    2
-SUB.f	r10,		r10,	    r11
-
-; If alignments are different, will never match alignment
-bne		@.L_start_1byte_search_src
-
-; If address is 4 byte aligned, we can just directly read 4 bytes
-bmsk.f	r3,		r13,		1
-beq.d			@.L_4B_step_src
-
-subl	r3,		r3,		1		; [0]
-asl		r3,		r3,		2		; [1]
-
-; Jump depending on the alignment
-bi	    [r3]
-; Read 3 bytes
-ldb.ab	r10,	[r1,	+1]
-cmp		r10,	0
-beq.d			@.L_return_dest
-stb.ab	r10,	[r13,	+1]
-
-; Read 2 bytes
-ldb.ab	r10,	[r1,	+1]
-cmp		r10,	0
-beq.d			@.L_return_dest
-stb.ab	r10,	[r13,	+1]
-
-; Read 1 byte
-ldb.ab	r10,	[r1,	+1]
-cmp		r10,	0
-beq.d			@.L_return_dest
-stb.ab	r10,	[r13,	+1]
-
-
-; By this point, r13 and r1 are either 4 or 8 byte aligned, with
-; matching alignments
-.L_4B_step_src:
-
-; If aligned to 8 bytes, just jump ahead
-andl.f	0,		r1,		0b111
-beq.d			@.L_4_8B_search_src
-; Always reset bit mask that will encode NULL byte location
-xorl	r6,		r6,		r6
-
-ld.ab	r10,	[r1,	+4]
-sub		r11,	r10,	NULL_32DT_1
-bic		r11,	r11,	r10
-tst		r11,	NULL_32DT_2
-bne				@.L_reread_last_4bytes_src
-
-; NULL byte detector is already setup by strlen
-
-stl.ab	r10,	[r13,	+4]
+	xorl	r6, r6, r6
 
 .L_4_8B_search_src:
-		ldl.ab	r2,		[r1,	+8]
-		ldl.ab	r3,		[r1,	+8]
-		ldl.ab	r4,		[r1,	+8]
-		ldl.ab	r5,		[r1,	+8]
+; Using 128-bit memory operations
+#if defined (__ARC64_M128__)
 
-		; NULL byte position is detected and encoded in r6 [4] [5]
-		subl	r10,	r2,		r8
-		subl	r11,	r3,		r8
-		subl	r12,	r4,		r8
-		subl	r7,		r5,		r8
+	lddl.ab	r2r3, [r1, +16]
+	lddl.ab	r4r5, [r1, +16]
 
-		bicl	r10,	r10,	r2
-		bicl	r11,	r11,	r3
-		bicl	r12,	r12,	r4
-		bicl	r7,		r7,		r5
+; The 64-bit crunching implementation.
+#elif defined (__ARC64_ARCH64__)
 
-		tstl	r10,	r9
-		bset.ne	r6,		r6,		4
+	ldl.ab	r2, [r1, +8]
+	ldl.ab	r3, [r1, +8]
+	ldl.ab	r4, [r1, +8]
+	ldl.ab	r5, [r1, +8]
 
-		tstl	r11,	r9
-		bset.ne	r6,		r6,		3
+#else
+	# error Unknown configuration
+#endif
 
-		tstl	r12,	r9
-		bset.ne	r6,		r6,		2
+; NULL byte position is detected and encoded in r6 [4] [5]
+	subl	r10, r2, r8
+	subl	r11, r3, r8
+	subl	r12, r4, r8
+	subl	r7, r5, r8
 
-		tstl	r7,		r9
-		bset.ne	r6,		r6,		1
+	bicl	r10, r10, r2
+	bicl	r11, r11, r3
+	bicl	r12, r12, r4
+	bicl	r7, r7, r5
 
-		brne	r6,		0,		@.L_found_in_32B
+	tstl	r10, r9
+	bset.ne	r6, r6, 4
 
-		stl.ab	r2,	[r13,	+8]
-		stl.ab	r3,	[r13,	+8]
-		stl.ab	r4,	[r13,	+8]
-		stl.ab	r5,	[r13,	+8]
+	tstl	r11, r9
+	bset.ne	r6, r6, 3
 
-		j 		@.L_4_8B_search_src
+	tstl	r12, r9
+	bset.ne	r6, r6, 2
+
+	tstl	r7, r9
+	bset.ne	r6, r6, 1
+
+	brne	r6, 0, @.L_found_in_32B
+
+; Using 128-bit memory operations
+#if defined (__ARC64_M128__)
+
+	stdl.ab	r2r3, [r13, +16]
+	stdl.ab	r4r5, [r13, +16]
+
+; The 64-bit crunching implementation.
+#elif defined (__ARC64_ARCH64__)
+
+	stl.ab	r2, [r13, +8]
+	stl.ab	r3, [r13, +8]
+	stl.ab	r4, [r13, +8]
+	stl.ab	r5, [r13, +8]
+
+#else
+# error Unknown configuration
+#endif
+
+j 		@.L_4_8B_search_src
 
 .L_found_in_32B:
 
-; Back track only what is required [5]
-fls		r6,		r6
+fls	r6, r6 ; [2]
 
-asl		r5,		r6,		3
-sub		r6,		r6,		1
+; Point r13 to first NULL byte containing double word [3]
+	sub3l	r1, r1, r6
 
-subl	r1,		r1,		r5
-asl		r6,		r6,		2
+; Select appropriate register to analyze [4]
+	subl	r6, r6, 1
+; Invert so the biggest branch is at the end, and we dont need to increase
+; block size
+	subl	r6, 3, r6
 
-bi		[r6]
-stl.ab	r2,		[r13,	+8]
-stl.ab	r3,		[r13,	+8]
-stl.ab	r4,		[r13,	+8]
-b				@.L_start_1byte_search_src
+	mpyl	r6, r6, 5
 
-stl.ab	r2,		[r13,	+8]
-stl.ab	r3,		[r13,	+8]
-b				@.L_start_1byte_search_src
-nop
+; Store double words
+	bi	[r6]
 
-stl.ab	r2,		[r13,	+8]
-nop
-nop
-nop
+	MOVP	r10, r10
+	MOVP	r11, r2
+	b	@.L_fix_r1
+	nop
+	nop
 
-; Passthrough to last branch
+	stl.ab	r2, [r13, +8]
+	MOVP	r10, r11
+	MOVP	r11, r3
+	b	@.L_fix_r1
+	nop
 
-b		@.L_start_1byte_search_src
+	stl.ab	r2, [r13, +8]
+	stl.ab	r3, [r13, +8]
+	MOVP	r10, r12
+	MOVP	r11, r4
+	b	@.L_fix_r1
 
-.L_reread_last_4bytes_src:
+	stl.ab	r2, [r13, +8]
+	stl.ab	r3, [r13, +8]
+	stl.ab	r4, [r13, +8]
+	MOVP	r10, r7
+	MOVP	r11, r5
 
-subl	r1,     r1,     4
+; r10 contains 
+; r11 contains the last 64 bits to potentially write
 
-; Perform 1 byte search until NULL byte is found
-.L_start_1byte_search_src:
+; Point r13 to first NULL byte in selected double word
+.L_fix_r1:
+	andl	r10, r10, r9 ; [5]
+; R10 now has only the highest bit in each byte set, for NULL bytes.
+; So, we find the rightmost bit, which will belong to the first NULL byte, counting from the right.
+; r10 will be 0 to 7
 
-		; Look for NULL byte
-		ldb.ab	r11,	[r1, 	+1]
-		cmp		r11,	0
+	ffsl	r12, r10 ; [6]
 
-		bne.d   		@.L_start_1byte_search_src
-		stb.ab	r11,	[r13, 	+1]
+	addl	r12, r12, 1 ; [6]
 
-.L_return_dest:
-j_s	[blink]
+	xbful 	r12, r12, 0b00111000011 ; [7]
+
+; r12 now contains which byte the last NULL byte is
+; If r12 is 0, the NULL byte is the last one and we need to copy 7 bytes,
+; if it is 7, we need to copy 0 bytes
+
+;ldl.ab	r2, [r13, +8]
+
+; How many bytes to copy is in r10 now
+
+	subl	r12, 8, r12
+
+	asl		r12, r12, 1
+
+	bi [r12]
+
+	stb.ab	r11, [r13, +1]
+	lsrl	r11, r11, 8
+
+	stb.ab	r11, [r13, +1]
+	lsrl	r11, r11, 8
+
+	stb.ab	r11, [r13, +1]
+	lsrl	r11, r11, 8
+
+	stb.ab	r11, [r13, +1]
+	lsrl	r11, r11, 8
+
+	stb.ab	r11, [r13, +1]
+	lsrl	r11, r11, 8
+
+	stb.ab	r11, [r13, +1]
+	lsrl	r11, r11, 8
+
+	stb.ab	r11, [r13, +1]
+	lsrl	r11, r11, 8
+
+	stb.ab	r11, [r13, +1]
+	nop
+
+	j_s.d	[blink]
 
 
 ENDFUNC (strcat)
@@ -395,6 +391,3 @@ ENDFUNC (strcat)
 ; The nops are very important to keep the alignment of the jump
 ;
 ;
-
-
-#endif

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -71,10 +71,19 @@ ENTRY (strcat)
 
 .L_4_4B_search:
 
+#if defined (__ARC64_LL64__)
+
+	ldd.ab	r2r3, [r13, +8]
+	ldd.ab	r4r5, [r13, +8]
+
+#else
+
 	ld.ab	r2, [r13, +4]
 	ld.ab	r3, [r13, +4]
 	ld.ab	r4, [r13, +4]
 	ld.ab	r5, [r13, +4]
+
+#endif
 
 ; NULL byte position is detected and encoded in r6 [0] [9]
 	sub	r10, r2, r8
@@ -137,10 +146,19 @@ ENTRY (strcat)
 
 .L_4_4B_search_src:
 
+#if defined (__ARC64_LL64__)
+
+	ldd.ab	r2r3, [r1, +8]
+	ldd.ab	r4r5, [r1, +8]
+
+#else
+
 	ld.ab	r2, [r1, +4]
 	ld.ab	r3, [r1, +4]
 	ld.ab	r4, [r1, +4]
 	ld.ab	r5, [r1, +4]
+
+#endif
 
 ; NULL byte position is detected and encoded in r6 [0] [9]
 	sub	r10, r2, r8
@@ -194,42 +212,38 @@ ENTRY (strcat)
 	; Condense the two subs here
 	sub	r6, 4, r6
 
-	mpy	r6, r6, 5
+	asl	r6, r6, 2
 
 ; Store double words
 	bi	[r6]
 
-	mov	r10, r10
 	mov	r11, r2
 	b	@.L_store_lastL32bits
 	nop
 	nop
 
 	st.ab	r2, [r13, +4]
-	mov	r10, r11
 	mov	r11, r3
 	b	@.L_store_lastL32bits
 	nop
 
 	st.ab	r2, [r13, +4]
 	st.ab	r3, [r13, +4]
-	mov	r10, r12
 	mov	r11, r4
 	b	@.L_store_lastL32bits
 
 	st.ab	r2, [r13, +4]
 	st.ab	r3, [r13, +4]
 	st.ab	r4, [r13, +4]
-	mov	r10, r7
 	mov	r11, r5
 
 ; r11 now contains the data to write
-; r10 contains most of the NULL byte detector operation
 .L_store_lastL32bits:
-
+	sub r10, r11, r8
+	bic	r10, r10, r11
 	and	r10, r10, r9 ; [5]
 
-	ffs	r2, r10 ; [6]
+	ffs	r2, r11 ; [6]
 	add	r2, r2, 1
 
 	xbfu 	r2, r2, 0b0111000011 ; [7]
@@ -442,38 +456,35 @@ ENTRY (strcat)
 	; Condense the two subs here
 	subl	r6, 4, r6
 
-	mpyl	r6, r6, 5
+	asll		r6, r6, 2
 
 ; Store double words
 	bi	[r6]
 
-	MOVP	r10, r10
 	MOVP	r11, r2
 	b	@.L_store_lastL64bits
 	nop
 	nop
 
 	stl.ab	r2, [r13, +8]
-	MOVP	r10, r11
 	MOVP	r11, r3
 	b	@.L_store_lastL64bits
 	nop
 
 	stl.ab	r2, [r13, +8]
 	stl.ab	r3, [r13, +8]
-	MOVP	r10, r12
 	MOVP	r11, r4
 	b	@.L_store_lastL64bits
 
 	stl.ab	r2, [r13, +8]
 	stl.ab	r3, [r13, +8]
 	stl.ab	r4, [r13, +8]
-	MOVP	r10, r7
 	MOVP	r11, r5
 
 ; r11 now contains the data to write
-; r10 contains most of the NULL byte detector operation
 .L_store_lastL64bits:
+	subl	r10, r11, r8
+	bicl	r10, r10, r11
 
 	andl	r10, r10, r9 ; [5]
 

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -243,17 +243,17 @@ ENTRY (strcat)
 	bic	r10, r10, r11
 	and	r10, r10, r9 ; [5]
 
-	ffs	r2, r11 ; [6]
+	ffs	r2, r10 ; [6]
 	add	r2, r2, 1
 
-	xbfu 	r2, r2, 0b0111000011 ; [7]
+	xbfu	r2, r2, 0b0111000011 ; [7]
 
 	mov	r3, 0xffffffffffffffff	; Bitmask setup
 
 	; If the NULL byte is in byte 3 (starting from the right)
 	; we want to store 8-3 bytes
 	sub	r2, 8, r2
-	asl		r2, r2, 3
+	asl	r2, r2, 3
 
 	; According to the target byte, setup masks
 	lsr	r3, r3, r2
@@ -267,7 +267,7 @@ ENTRY (strcat)
 	and	r3, r3, r11
 	and	r4, r4, r10
 
-	or		r3, r3, r4
+	or	r3, r3, r4
 
 	st.ab	r3, [r13, +4]
 

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -36,6 +36,25 @@
 
 ; dest and src MUST NOT intercept
 
+; Brief:
+; Perform the same operation as strlen for finding the end
+; of r0
+; If r0 and r1 have
+; If 4 byte aligned
+; 	Do 4 byte search until there are no more 4 byte chunks
+;	Then, do 1 byte search
+; Otherwise, 1 byte search until alignment
+;	Then, do 4 byte search as previously specified
+;
+;; More in depth description at the end
+;
+; R0 void* ptr
+; R1 int ch
+; R2 size_t count
+; ret (R0):
+;		- 0 : Byte not found
+;		- Byte position
+
 ENTRY (strcat)
 ; Find end of r0
 ; ========================== STRLEN CODE START ==========================
@@ -113,6 +132,33 @@ ldb		r10,	[r13]
 
 	; If alignments are different, will never match alignment
 	bne		@.L_start_1byte_search
+    
+    ; Aligned at 4 byte!
+	bmsk.f	r3,		r13,		1
+	beq.d			@.L_start_4byte_search_src
+
+	SUBP	r3,		r3,		1		; [0]
+	asl		r3,		r3,		2		; [1]
+
+	; r3 now represents the inverse of the amount of instructions to skip
+	bi	    [r3]
+; Read 3 bytes
+	ldb.ab	r10,	[r1,	+1]
+	cmp		r10,	0
+	beq.d			@.L_return_ptr
+    stb.ab	r10,	[r13,	+1]
+; Read 2 bytes
+	ldb.ab	r10,	[r1,	+1]
+	cmp		r10,	0
+	beq.d			@.L_return_ptr
+    stb.ab	r10,	[r13,	+1]
+; Read 1 byte
+	ldb.ab	r10,	[r1,	+1]
+	cmp		r10,	0
+	beq.d			@.L_return_ptr
+    stb.ab	r10,	[r13,	+1]
+
+.L_start_4byte_search_src:
 
 ld.ab	r11,	[r1, +4]
 sub		r12, r11, r8

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -1,0 +1,124 @@
+/*
+   Copyright (c) 2021, Synopsys, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1) Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2) Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+   3) Neither the name of the Synopsys, Inc., nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <sys/asm.h>
+
+
+; r0 char* dest
+; r1 const char* src
+
+; dest and src MUST NOT intercept
+
+ENTRY (strcat)
+; Find end of r0
+; ========================== STRLEN CODE START ==========================
+
+	; address is 4 byte aligned, go to 4 byte search
+	bmsk.f	r3,		r0,		1
+	beq.d			@.L_start_4byte_search
+	MOVP	r13,	r0	; Store r0 for size calculation
+
+	SUBP	r3,		r3,		1		; [0]
+	asl		r3,		r3,		2		; [1]
+
+	; r3 now represents the inverse of the amount of instructions to skip
+	bi	    [r3]
+; Read 3 bytes
+	ldb.ab	r10,	[r13,	+1]
+	cmp		r10,	0
+	beq.d			@.L_string_end_found
+	SUBP	r2,		r2,		1
+; Read 2 bytes
+	ldb.ab	r10,	[r13,	+1]
+	cmp		r10,	0
+	beq.d			@.L_string_end_found
+	SUBP	r2,		r2,		1
+; Read 1 byte
+	ldb.ab	r10,	[r13,	+1]
+	cmp		r10,	0
+	beq.d			@.L_string_end_found
+	SUBP	r2,		r2,		1
+
+.L_start_4byte_search:
+	;; Setup byte detector (more information bellow)
+	mov		r8,		0x01010101
+	ror		r9,		r8
+
+	; Load next 4 bytes
+	ld.ab	r10,	[r13, +4]
+
+; Handle 4 byte chunks
+.L_search4byte_chunk:
+	
+	; Look for the NULL byte
+	sub		r2,		r10,	r8
+	bic		r2,		r2,		r10
+	tst		r2,		r9
+
+	; NULL byte not found yet
+	beq.d	@.L_search4byte_chunk
+	; Load next 4 bytes
+	ld.ab	r10,	[r13, +4]
+	
+; NULL byte found!
+; Backtrack 8 bytes [2]
+; 4 because of write-back, 4 because we dont know for sure where in the
+; 4 bytes the NULL byte is. Then perform 1 byte search
+	SUBP	r13,		r13,		8
+
+	ldb		r10,	[r13]
+
+;; 1 byte search until NULL byte is found
+.L_search_next_1byte_chunk:
+	cmp		r10,	0
+	bne.d	@.L_search_next_1byte_chunk
+	ldb.aw	r10,	[r13, +1]
+
+; NULL byte was found in r0 - 1
+.L_string_end_found:
+	SUBP	r13,		r13,	1
+
+; ========================== STRLEN CODE END >|< ==========================
+
+.L_search_next_1byte_chunk_src:
+
+	ldb.ab	r11,	[r1, +1]
+	; Look for NULL byte
+	cmp		r11,	0
+	beq.d	@.L_return_ptr
+
+	stb.ab	r11,	[r13, +1]
+	j		@.L_search_next_1byte_chunk_src
+
+.L_return_ptr:
+	j_s	[blink]
+
+
+ENDFUNC (strcat)

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -110,27 +110,24 @@ ENTRY (strcat)
 
 	breq.d	r6, 0, @.L_4_4B_search
 
-	fls	r6, r6 ; [2]
+	fls	r5, r6 ; [2]
 
 ; Point r13 to first NULL byte containing double word [3]
-	sub2	r13, r13, r6
+	sub2	r13, r13, r5
 
-; Select appropriate register to analyze [4]
-	sub	r6, r6, 1
-	asl r6, r6, 1
-
-	bi	[r6]
+	; Select appropriate register to analyze [4]
 	mov	r2, r7
-	b	@.L_fix_r13
-	mov	r2, r12
-	b	@.L_fix_r13
-	mov	r2, r11
-	b	@.L_fix_r13
-	mov	r2, r10
-	nop
+
+	asr.f	r6, r6, 3
+	mov.c	r2, r12
+
+	asr.f	r6, r6, 1
+	mov.c	r2, r11
+
+	asr.f	r6, r6, 1
+	mov.c	r2, r10
 
 ; Point r13 to first NULL byte in selected double word
-.L_fix_r13:
 	and	r2, r2, r9 ; [5]
 
 	ffs	r2, r2 ; [6]
@@ -185,10 +182,19 @@ ENTRY (strcat)
 
 	brne	r6, 0, @.L_found_in_32B
 
+#if defined (__ARC64_LL64__)
+
+	std.ab	r2r3, [r13, +8]
+	std.ab	r4r5, [r13, +8]
+
+#else
+
 	st.ab	r2, [r13, +4]
 	st.ab	r3, [r13, +4]
 	st.ab	r4, [r13, +4]
 	st.ab	r5, [r13, +4]
+
+#endif
 
 	j	@.L_4_4B_search_src
 
@@ -248,7 +254,7 @@ ENTRY (strcat)
 
 	xbfu	r2, r2, 0b0111000011 ; [7]
 
-	mov	r3, 0xffffffffffffffff	; Bitmask setup
+	mov	r3, -1; Bitmask setup
 
 	; If the NULL byte is in byte 3 (starting from the right)
 	; we want to store 8-3 bytes
@@ -338,24 +344,22 @@ ENTRY (strcat)
 
 	breq.d	r6, 0, @.L_4_8B_search
 
-	fls	r6, r6 ; [2]
+	fls	r5, r6 ; [2]
 
 ; Point r13 to first NULL byte containing double word [3]
-	sub3l	r13, r13, r6
+	sub3l	r13, r13, r5
 
-; Select appropriate register to analyze [4]
-	subl	r6, r6, 1
-	asl r6, r6, 1
-
-	bi	[r6]
+	; Select appropriate register to analyze [4]
 	MOVP	r2, r7
-	b	@.L_fix_r13
-	MOVP	r2, r12
-	b	@.L_fix_r13
-	MOVP	r2, r11
-	b	@.L_fix_r13
-	MOVP	r2, r10
-	nop
+
+	asr.f	r6, r6, 3
+	MOVP.c	r2, r12
+
+	asr.f	r6, r6, 1
+	MOVP.c	r2, r11
+
+	asr.f	r6, r6, 1
+	MOVP.c	r2, r10
 
 ; Point r13 to first NULL byte in selected double word
 .L_fix_r13:
@@ -373,13 +377,11 @@ ENTRY (strcat)
 	xorl	r6, r6, r6
 
 .L_4_8B_search_src:
-; Using 128-bit memory operations
 #if defined (__ARC64_M128__)
 
 	lddl.ab	r2r3, [r1, +16]
 	lddl.ab	r4r5, [r1, +16]
 
-; The 64-bit crunching implementation.
 #elif defined (__ARC64_ARCH64__)
 
 	ldl.ab	r2, [r1, +8]
@@ -416,13 +418,11 @@ ENTRY (strcat)
 
 	brne	r6, 0, @.L_found_in_32B
 
-; Using 128-bit memory operations
 #if defined (__ARC64_M128__)
 
 	stdl.ab	r2r3, [r13, +16]
 	stdl.ab	r4r5, [r13, +16]
 
-; The 64-bit crunching implementation.
 #elif defined (__ARC64_ARCH64__)
 
 	stl.ab	r2, [r13, +8]
@@ -456,7 +456,7 @@ ENTRY (strcat)
 	; Condense the two subs here
 	subl	r6, 4, r6
 
-	asll		r6, r6, 2
+	asll	r6, r6, 2
 
 ; Store double words
 	bi	[r6]
@@ -493,7 +493,7 @@ ENTRY (strcat)
 
 	xbful 	r2, r2, 0b0111000011 ; [7]
 
-	movl	r3, 0xffffffffffffffff	; Bitmask setup
+	movl	r3, -1; Bitmask setup
 
 	; If the NULL byte is in byte 3 (starting from the right)
 	; we want to store 8-3 bytes

--- a/newlib/libc/machine/arc64/strcat.S
+++ b/newlib/libc/machine/arc64/strcat.S
@@ -137,7 +137,7 @@ ENTRY (strcat)
 
 	ffsl	r2, r2 ; [6]
 
-	xbful 	r2, r2, 0b01111000011 ; [7]
+	xbful 	r2, r2, 0b0111000011 ; [7]
 
 	addl	r13, r13, r2 ; [8]
 
@@ -268,7 +268,7 @@ ENTRY (strcat)
 	ffsl	r2, r10 ; [6]
 	addl	r2, r2, 1
 
-	xbful 	r2, r2, 0b00111000011 ; [7]
+	xbful 	r2, r2, 0b0111000011 ; [7]
 
 	movl	r3, 0xffffffffffffffff	; Bitmask setup
 
@@ -356,9 +356,11 @@ ENDFUNC (strcat)
 ; NULL byte and we wouldnt be here) we dont need to worry about that. [6]
 ; 
 ; We can then convert the bit position into the last byte position by looking
-; into bits 3 to 6, and shifting 3 bits to the right. This can be combined into
+; into bits 3 to 5, and shifting 3 bits to the right. This can be combined into
 ; a single xbful operation. The bottom 000011 represent shift by 3 and the top
-; 01111 represents the mask (3 to 6 shifted by 3 is 0 to 3) [7]
+; 0111 represents the mask (3 to 5 shifted by 3 is 0 to 2). We dont need to worry
+; about the case where ffs does not find a bit, because we know for sure there is
+; at least one NULL byte, and therefore one of the highest bits is set to 1 [7]
 ; 
 ; Finally, we can add the NULL byte position inside the loaded double word to
 ; r13 and subtract r0 from r13 to obtain the string size [8]


### PR DESCRIPTION
Created assembly version of strcat with the objective of focusing on speed for larger amounts of memory/bigger strings.
Used measure of speed is instruction count via CPU counters.
Measurements against compiler generated code suggest a decrease in instruction count of around 75%.
Half of this code is based on the newly optimized strlen assembly function.
Newlib DejaGNU tests pass with success!