### PR TITLE
Fix dw_uart build

### DIFF
--- a/libgloss/arc/dw_uart/device/device_hal/inc/dev_uart.h
+++ b/libgloss/arc/dw_uart/device/device_hal/inc/dev_uart.h
@@ -64,6 +64,8 @@
 #ifndef _DEVICE_HAL_UART_H_
 #define _DEVICE_HAL_UART_H_
 
+#include <stdint.h>
+
 /**
  *   Device callback function typedef.
  * This is usually used in device callback settings,


### PR DESCRIPTION
The dw_uart build broke with:
  Commit 357d7fcc6
  In <stdio.h> provide only necessary types

The above commit exposed a latent missing-header bug:
```
In file included from ../../../../../../libgloss/arc/dw_uart/common/console_io.c:40: ../../../../../../libgloss/arc/dw_uart/device/device_hal/inc/dev_uart.h:81:2: error: unknown type name 'uint32_t'
   81 |  uint32_t len; /*!< buffer length in bytes */
      |  ^~~~~~~~
```

Fix by including <stdint.h>.

Inspired by 90a4ab5eb "Fix nano-malloc build".