### PR TITLE
Optimized memmove implementation

### DIFF
--- a/newlib/libc/machine/arc64/Makefile.am
+++ b/newlib/libc/machine/arc64/Makefile.am
@@ -14,6 +14,7 @@ lib_a_SOURCES =                 \
         memset.S                \
         memset-stub.c           \
         strlen.S                \
+        memmove.S               \
         setjmp.S
 
 lib_a_CCASFLAGS=$(AM_CCASFLAGS)

--- a/newlib/libc/machine/arc64/Makefile.in
+++ b/newlib/libc/machine/arc64/Makefile.in
@@ -121,7 +121,8 @@ lib_a_LIBADD =
 am_lib_a_OBJECTS = lib_a-memcmp.$(OBJEXT) lib_a-memcmp-stub.$(OBJEXT) \
 	lib_a-memcpy.$(OBJEXT) lib_a-memcpy-stub.$(OBJEXT) \
 	lib_a-memset.$(OBJEXT) lib_a-memset-stub.$(OBJEXT) \
-	lib_a-strlen.$(OBJEXT) lib_a-setjmp.$(OBJEXT)
+	lib_a-strlen.$(OBJEXT) lib_a-memmove.$(OBJEXT) \
+	lib_a-setjmp.$(OBJEXT)
 lib_a_OBJECTS = $(am_lib_a_OBJECTS)
 AM_V_P = $(am__v_P_@AM_V@)
 am__v_P_ = $(am__v_P_@AM_DEFAULT_V@)
@@ -347,6 +348,7 @@ lib_a_SOURCES = \
         memset.S                \
         memset-stub.c           \
         strlen.S                \
+        memmove.S               \
         setjmp.S
 
 lib_a_CCASFLAGS = $(AM_CCASFLAGS)
@@ -431,6 +433,12 @@ lib_a-strlen.o: strlen.S
 
 lib_a-strlen.obj: strlen.S
 	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-strlen.obj `if test -f 'strlen.S'; then $(CYGPATH_W) 'strlen.S'; else $(CYGPATH_W) '$(srcdir)/strlen.S'; fi`
+
+lib_a-memmove.o: memmove.S
+	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-memmove.o `test -f 'memmove.S' || echo '$(srcdir)/'`memmove.S
+
+lib_a-memmove.obj: memmove.S
+	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-memmove.obj `if test -f 'memmove.S'; then $(CYGPATH_W) 'memmove.S'; else $(CYGPATH_W) '$(srcdir)/memmove.S'; fi`
 
 lib_a-setjmp.o: setjmp.S
 	$(AM_V_CPPAS)$(CCAS) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(AM_CPPFLAGS) $(CPPFLAGS) $(lib_a_CCASFLAGS) $(CCASFLAGS) -c -o lib_a-setjmp.o `test -f 'setjmp.S' || echo '$(srcdir)/'`setjmp.S

--- a/newlib/libc/machine/arc64/memmove.S
+++ b/newlib/libc/machine/arc64/memmove.S
@@ -33,39 +33,38 @@ ENTRY (memmove)
 	bmsk_s	r2, r2, 3
 
 	bbit0.d	r2, 1, @1f
-	lsr	r11, r2, 2
-	ldh.ab	r4, [r1, -2]
-	sth.ab	r4, [r3, -2]
+	lsr	r5, r2, 2
+	ldh.aw	r4, [r1, -2]
+	sth.aw	r4, [r3, -2]
 1:
 	bbit0.d	r2, 0, @1f
-	xor	r11, r11, 3
-	ldb.ab	r4, [r1, -1]
-	stb.ab	r4, [r3, -1]
+	xor	r5, r5, 3
+	ldb.aw	r4, [r1, -1]
+	stb.aw	r4, [r3, -1]
 1:
-	asl	r11, r11, 1
-	bi	[r11]
-	ld.ab	r4,[r1, -4]
-	st.ab	r4,[r3, -4]
-	ld.ab	r4,[r1, -4]
-	st.ab	r4,[r3, -4]
-	ld	r4,[r1]
-	st	r4,[r3]
+	asl	r5, r5, 1
+	bi	[r5]
+	ld.aw	r4,[r1, -4]
+	st.aw	r4,[r3, -4]
+	ld.aw	r4,[r1, -4]
+	st.aw	r4,[r3, -4]
+	ld.aw	r4,[r1, -4]
+	st.aw	r4,[r3, -4]
 
 ; Jump if there are no 16 byte chunks
 
 	jeq	[blink]
 
 .L_write_backwards_16_bytes:
-	ld.ab	r4, [r1, 4]
-	ld.ab	r5, [r1, 4]
-	ld.ab	r6, [r1, 4]
-	ld.ab	r7, [r1, 4]
-	st.ab	r4, [r3, 4]
-	st.ab	r5, [r3, 4]
-	st.ab	r6, [r3, 4]
+	ld.aw	r4, [r1, -4]
+	ld.aw	r5, [r1, -4]
+	ld.aw	r6, [r1, -4]
+	ld.aw	r7, [r1, -4]
+	st.aw	r4, [r3, -4]
+	st.aw	r5, [r3, -4]
+	st.aw	r6, [r3, -4]
 	dbnz.d	r11, @.L_write_backwards_16_bytes
-	st.ab	r7, [r3, 4]
-	bmsk_s	r2, r2, 3
+	st.aw	r7, [r3, -4]
 
 	j_s	[blink]
 

--- a/newlib/libc/machine/arc64/memmove.S
+++ b/newlib/libc/machine/arc64/memmove.S
@@ -4,35 +4,134 @@
 ; r1 const void* src
 ; r2 size_t count
 
-
-
-; Using 128-bit memory operations
-
-
 ; The 64-bit crunching implementation.
 
-ENTRY (memmove)
-	; If the source plus count is greater than the destination
-	; There is an overlap, and a backwards copy must be performed
-	;add		r4, r1, r2
-	LSRP.f	r12, r2, 5		; counter for 32-byte chunks
-	
-	; Dst is less than src, can safely perform normal memcpy
-	BRLO.d		r0, r1, @.L_normal_memcpy
-	addl		r4, r1, r2
+#if defined (__ARC64_ARCH32__) && !defined(__ARC64_LL64__)
 
-	BRLO.d		r4, r0, @.L_normal_memcpy
-	; Only relevant when not taking the branch, but might as well
-	; use the delay slot (after the branch, this will be redone
-	addl	r3, r0, r2
+ENTRY (memmove)
+
+; If the source plus count is greater than the destination
+; There is an overlap, and a backwards copy must be performed
+	lsr.f	r11, r2, 4		; counter for 16-byte chunks
+	
+; Dst is less than src, can safely perform normal memcpy
+	BRLO.d	r0, r1, @.L_normal_memcpy
+	ADDP	r4, r1, r2
+
+	BRLO.d	r4, r0, @.L_normal_memcpy
+; Only relevant when not taking the branch, but might as well
+; use the delay slot (after the branch, this will be redone
+	ADDP	r3, r0, r2
+
 ; Backwards search
 ; The only thing that changes between memcpy and memmove is copy direction
 ; in case the dest and src address memory locations overlap
 ; More detailed information is in the forwards copy and at the end of
 ; this document
 
-	; Set both r0 and r1 to point to the end of eahc memory location
-	addl	r1, r1, r2
+	ADDP	r1, r1, r2
+	bmsk_s	r2, r2, 3
+
+	bbit0.d	r2, 1, @1f
+	lsr	r11, r2, 2
+	ldh.ab	r4, [r1, -2]
+	sth.ab	r4, [r3, -2]
+1:
+	bbit0.d	r2, 0, @1f
+	xor	r11, r11, 3
+	ldb.ab	r4, [r1, -1]
+	stb.ab	r4, [r3, -1]
+1:
+	asl	r11, r11, 1
+	bi	[r11]
+	ld.ab	r4,[r1, -4]
+	st.ab	r4,[r3, -4]
+	ld.ab	r4,[r1, -4]
+	st.ab	r4,[r3, -4]
+	ld	r4,[r1]
+	st	r4,[r3]
+
+; Jump if there are no 16 byte chunks
+
+	jeq	[blink]
+
+.L_write_backwards_16_bytes:
+	ld.ab	r4, [r1, 4]
+	ld.ab	r5, [r1, 4]
+	ld.ab	r6, [r1, 4]
+	ld.ab	r7, [r1, 4]
+	st.ab	r4, [r3, 4]
+	st.ab	r5, [r3, 4]
+	st.ab	r6, [r3, 4]
+	dbnz.d	r11, @.L_write_backwards_16_bytes
+	st.ab	r7, [r3, 4]
+	bmsk_s	r2, r2, 3
+
+	j_s	[blink]
+
+.L_normal_memcpy:
+	beq.d	@.L_write_forwards_15_bytes
+	mov	r3, r0			; work on a copy of "r0"
+
+.L_write_forwards_16_bytes:
+	ld.ab	r4, [r1, 4]
+	ld.ab	r5, [r1, 4]
+	ld.ab	r6, [r1, 4]
+	ld.ab	r7, [r1, 4]
+	st.ab	r4, [r3, 4]
+	st.ab	r5, [r3, 4]
+	st.ab	r6, [r3, 4]
+	dbnz.d	r11, @.L_write_forwards_16_bytes
+	st.ab	r7, [r3, 4]
+	bmsk_s	r2, r2, 3
+
+.L_write_forwards_15_bytes:
+	bbit0.d	r2, 1, @1f
+	lsr	r11, r2, 2
+	ldh.ab	r4, [r1, 2]
+	sth.ab	r4, [r3, 2]
+1:
+	bbit0.d	r2, 0, @1f
+	xor	r11, r11, 3
+	ldb.ab	r4, [r1, 1]
+	stb.ab	r4, [r3, 1]
+1:
+	asl	r11, r11, 1
+	bi	[r11]
+	ld.ab	r4,[r1, 4]
+	st.ab	r4,[r3, 4]
+	ld.ab	r4,[r1, 4]
+	st.ab	r4,[r3, 4]
+	ld	r4,[r1]
+	st	r4,[r3]
+
+	j_s	[blink]
+
+ENDFUNC (memmove)
+
+#else
+
+ENTRY (memmove)
+; If the source plus count is greater than the destination
+; There is an overlap, and a backwards copy must be performed
+	LSRP.f	r12, r2, 5		; counter for 32-byte chunks
+	
+; Dst is less than src, can safely perform normal memcpy
+	BRLO.d	r0, r1, @.L_normal_memcpy
+	ADDP	r4, r1, r2
+
+	BRLO.d	r4, r0, @.L_normal_memcpy
+; Only relevant when not taking the branch, but might as well
+; use the delay slot (after the branch, this will be redone
+	ADDP	r3, r0, r2
+; Backwards search
+; The only thing that changes between memcpy and memmove is copy direction
+; in case the dest and src address memory locations overlap
+; More detailed information is in the forwards copy and at the end of
+; this document
+
+; Set both r0 and r1 to point to the end of eahc memory location
+	ADDP	r1, r1, r2
 	bmsk_s	r2, r2, 4
 
 	bbit0.d	r2, 0, @1f
@@ -58,6 +157,7 @@ ENTRY (memmove)
 	LD64.aw	r4, [r1, -8]
 	ST64.aw	r4, [r3, -8]
 
+; Jump if there are no 32 byte chunks
 	jeq	[blink]
 
 .L_write_backwards_32_bytes:			; Take care of 32 byte chunks
@@ -70,12 +170,13 @@ ENTRY (memmove)
 	stdl.aw	r6r7, [r3, -16]
 	dbnz	r12, @.L_write_backwards_32_bytes
 
-#elif defined (__ARC64_ARCH64__)
+#elif defined (__ARC64_ARCH64__) || (  defined (__ARC64_ARCH32__) && defined (__ARC64_LL64__) )
 
 	LD64.aw	r4, [r1, -8]
 	LD64.aw	r6, [r1, -8]
 	LD64.aw	r8, [r1, -8]
 	LD64.aw	r10,[r1, -8]
+
 	ST64.aw	r4, [r3, -8]
 	ST64.aw	r6, [r3, -8]
 	ST64.aw	r8, [r3, -8]
@@ -90,9 +191,11 @@ ENTRY (memmove)
 
 ; Normal memcpy
 .L_normal_memcpy:
-	LSRP.f	r12, r2, 5		; counter for 32-byte chunks
+	;LSRP.f	r12, r2, 5		; Moved up
+
 	beq.d	@.L_write_forwards_31_bytes
 	MOVP	r3, r0			; do not clobber the "dest"
+
 .L_write_forwards_32_bytes:			; Take care of 32 byte chunks
 #if defined (__ARC64_M128__)
 
@@ -103,7 +206,7 @@ ENTRY (memmove)
 	stdl.ab	r6r7, [r3, +16]
 	dbnz	r12, @.L_write_forwards_32_bytes
 
-#elif defined (__ARC64_ARCH64__)
+#elif defined (__ARC64_ARCH64__) || (  defined (__ARC64_ARCH32__) && defined (__ARC64_LL64__) )
 
 	LD64.ab	r4, [r1, +8]
 	LD64.ab	r6, [r1, +8]
@@ -118,7 +221,6 @@ ENTRY (memmove)
 #else
 # error Unknown configuration
 #endif
-
 
 	bmsk_s	r2, r2, 4		; From now on, we only care for the remainder % 32
 
@@ -178,4 +280,5 @@ ENTRY (memmove)
 
 ENDFUNC (memmove)
 
+#endif
 

--- a/newlib/libc/machine/arc64/memmove.S
+++ b/newlib/libc/machine/arc64/memmove.S
@@ -4,8 +4,11 @@
 ; r1 const void* src
 ; r2 size_t count
 
+<<<<<<< HEAD
 #if defined (__ARC64_ARCH64__)
 
+=======
+>>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 ENTRY (memmove)
 	; If the source plus count is greater than the destination
 	; There is an overlap, and a backwards copy must be performed
@@ -14,11 +17,16 @@ ENTRY (memmove)
 	
 	; Dst is less than src, can safely perform normal memcpy
 	BRLO.d		r0, r1, @.L_normal_memcpy
+<<<<<<< HEAD
 	addl		r4, r1, r2
+=======
+	ADDP		r4, r1, r2
+>>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 
 	BRLO.d		r4, r0, @.L_normal_memcpy
 	; Only relevant when not taking the branch, but might as well
 	; use the delay slot (after the branch, this will be redone
+<<<<<<< HEAD
 	addl	r3, r0, r2
 ; Backwards search
 ; The only thing that changes between memcpy and memmove is copy direction
@@ -30,6 +38,22 @@ ENTRY (memmove)
 	addl	r1, r1, r2
 	bmsk_s	r2, r2, 4
 
+=======
+	ADDP	r3, r0, r2
+
+	;BRGT.d	r0, r4, @.L_backwards_search
+
+; Backwards search
+; The only thing that changes between memcpy and memmove is copy direction
+; in case the dest and src address memory locations overlap
+; For a scratch implementation, have separate code for incremental and decremental copies	
+	; Set both r0 and r1 to point to the end of eahc memory location
+	ADDP	r1, r1, r2
+	bmsk_s	r2, r2, 4
+
+; Take care of the last 31 bytes
+.L_B_write_31_bytes:
+>>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 	bbit0.d	r2, 0, @1f
 	lsr	r11, r2, 3
 	ldb.aw	r4, [r1, -1]
@@ -53,9 +77,17 @@ ENTRY (memmove)
 	LD64.aw	r4, [r1, -8]
 	ST64.aw	r4, [r3, -8]
 
+<<<<<<< HEAD
 	jeq	[blink]
 
 .L_write_backwards_32_bytes:			; Take care of 32 byte chunks
+=======
+; Do we have more than 32 bytes to take care of?
+	jeq	[blink]
+
+; Only take care of the 32 byte chunks at the end
+.L_B_write_32_bytes:
+>>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 	LD64.aw	r4, [r1, -8]
 	LD64.aw	r6, [r1, -8]
 	LD64.aw	r8, [r1, -8]
@@ -63,6 +95,7 @@ ENTRY (memmove)
 	ST64.aw	r4, [r3, -8]
 	ST64.aw	r6, [r3, -8]
 	ST64.aw	r8, [r3, -8]
+<<<<<<< HEAD
 	dbnz.d	r12, @.L_write_backwards_32_bytes
 	ST64.aw	r10, [r3, -8]
     
@@ -74,6 +107,23 @@ ENTRY (memmove)
 	beq.d	@.L_write_forwards_31_bytes
 	MOVP	r3, r0			; do not clobber the "dest"
 .L_write_forwards_32_bytes:			; Take care of 32 byte chunks
+=======
+	dbnz.d	r12, @.L_B_write_32_bytes
+	ST64.aw	r10, [r3, -8]
+
+	j_s	[blink]
+
+
+; Normal memcpy
+.L_normal_memcpy:
+
+	; Flags were set by LSRP.f, meaning it will jump if
+	; there are no 32 byte chunks
+	beq.d	@.L_F_write_31_bytes
+	MOVP	r3, r0			; do not clobber the "dest"
+
+.L_F_write_32_bytes:
+>>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 	LD64.ab	r4, [r1, +8]
 	LD64.ab	r6, [r1, +8]
 	LD64.ab	r8, [r1, +8]
@@ -81,6 +131,7 @@ ENTRY (memmove)
 	ST64.ab	r4, [r3, +8]
 	ST64.ab	r6, [r3, +8]
 	ST64.ab	r8, [r3, +8]
+<<<<<<< HEAD
 	dbnz.d	r12, @.L_write_forwards_32_bytes
 	ST64.ab	r10, [r3, +8]	; Shove store in delay slot
 	bmsk_s	r2, r2, 4		; From now on, we only care for the remainder % 32
@@ -130,6 +181,29 @@ ENTRY (memmove)
 ;	asl	    r12, r12, 1    [3]
 1:
 	bi	    [r12]
+=======
+	dbnz.d	r12, @.L_F_write_32_bytes
+	ST64.ab	r10, [r3, +8]
+	bmsk_s	r2, r2, 4
+
+.L_F_write_31_bytes:
+	bbit0.d	r2, 2, @1f
+	lsr	r12, r2, 3
+	ld.ab	r4, [r1, 4]
+	st.ab	r4, [r3, 4]
+1:
+	bbit0.d	r2, 1, @1f
+	xor	r12, r12, 3
+	ldh.ab	r4, [r1, 2]
+	sth.ab	r4, [r3, 2]
+1:
+	bbit0.d	r2, 0, @1f
+	asl	r12, r12, 1
+	ldb.ab	r4, [r1, 1]
+	stb.ab	r4, [r3, 1]
+1:
+	bi	[r12]
+>>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 	LD64.ab	r4, [r1, 8]
 	ST64.ab	r4, [r3, 8]
 	LD64.ab	r4, [r1, 8]
@@ -139,7 +213,13 @@ ENTRY (memmove)
 
 	j_s	[blink]
 
+<<<<<<< HEAD
 ENDFUNC (memmove)
 
 #endif
+=======
+
+
+ENDFUNC (memmove)
+>>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 

--- a/newlib/libc/machine/arc64/memmove.S
+++ b/newlib/libc/machine/arc64/memmove.S
@@ -51,8 +51,7 @@ ENTRY (memmove)
 	ld.aw	r4,[r1, -4]
 	st.aw	r4,[r3, -4]
 
-; Jump if there are no 16 byte chunks
-
+; Return if there are no 16 byte chunks
 	jeq	[blink]
 
 .L_write_backwards_16_bytes:

--- a/newlib/libc/machine/arc64/memmove.S
+++ b/newlib/libc/machine/arc64/memmove.S
@@ -20,17 +20,16 @@ ENTRY (memmove)
 	; Only relevant when not taking the branch, but might as well
 	; use the delay slot (after the branch, this will be redone
 	addl	r3, r0, r2
-
 ; Backwards search
 ; The only thing that changes between memcpy and memmove is copy direction
 ; in case the dest and src address memory locations overlap
-; For a scratch implementation, have separate code for incremental and decremental copies	
+; More detailed information is in the forwards copy and at the end of
+; this document
+
 	; Set both r0 and r1 to point to the end of eahc memory location
 	addl	r1, r1, r2
 	bmsk_s	r2, r2, 4
 
-; Take care of the last 31 bytes
-.L_B_write_31_bytes:
 	bbit0.d	r2, 0, @1f
 	lsr	r11, r2, 3
 	ldb.aw	r4, [r1, -1]
@@ -54,11 +53,9 @@ ENTRY (memmove)
 	LD64.aw	r4, [r1, -8]
 	ST64.aw	r4, [r3, -8]
 
-; Do we have more than 32 bytes to take care of?
 	jeq	[blink]
 
-; Only take care of the 32 byte chunks at the end
-.L_B_write_32_bytes:
+.L_write_backwards_32_bytes:			; Take care of 32 byte chunks
 	LD64.aw	r4, [r1, -8]
 	LD64.aw	r6, [r1, -8]
 	LD64.aw	r8, [r1, -8]
@@ -66,21 +63,17 @@ ENTRY (memmove)
 	ST64.aw	r4, [r3, -8]
 	ST64.aw	r6, [r3, -8]
 	ST64.aw	r8, [r3, -8]
-	dbnz.d	r12, @.L_B_write_32_bytes
+	dbnz.d	r12, @.L_write_backwards_32_bytes
 	ST64.aw	r10, [r3, -8]
-
+    
 	j_s	[blink]
-
 
 ; Normal memcpy
 .L_normal_memcpy:
-
-	; Flags were set by LSRP.f, meaning it will jump if
-	; there are no 32 byte chunks
-	beq.d	@.L_F_write_31_bytes
+	LSRP.f	r12, r2, 5		; counter for 32-byte chunks
+	beq.d	@.L_write_forwards_31_bytes
 	MOVP	r3, r0			; do not clobber the "dest"
-
-.L_F_write_32_bytes:
+.L_write_forwards_32_bytes:			; Take care of 32 byte chunks
 	LD64.ab	r4, [r1, +8]
 	LD64.ab	r6, [r1, +8]
 	LD64.ab	r8, [r1, +8]
@@ -88,27 +81,55 @@ ENTRY (memmove)
 	ST64.ab	r4, [r3, +8]
 	ST64.ab	r6, [r3, +8]
 	ST64.ab	r8, [r3, +8]
-	dbnz.d	r12, @.L_F_write_32_bytes
-	ST64.ab	r10, [r3, +8]
-	bmsk_s	r2, r2, 4
+	dbnz.d	r12, @.L_write_forwards_32_bytes
+	ST64.ab	r10, [r3, +8]	; Shove store in delay slot
+	bmsk_s	r2, r2, 4		; From now on, we only care for the remainder % 32
 
-.L_F_write_31_bytes:
-	bbit0.d	r2, 2, @1f
-	lsr	r12, r2, 3
+
+; The remainder bits indicating how many more bytes to copy
+; .------------------------.
+; | b4 | b3 | b2 | b1 | b0 |
+; `------------------------'
+;   16    8    4    2    1
+.L_write_forwards_31_bytes:
+	bbit0.d	r2, 2, @1f		; is b2 set? then copy 4 bytes
+	lsr	    r12, r2, 3		; see the notes below
 	ld.ab	r4, [r1, 4]
 	st.ab	r4, [r3, 4]
 1:
-	bbit0.d	r2, 1, @1f
-	xor	r12, r12, 3
+	bbit0.d	r2, 1, @1f		; is b1 set? then copy 2 bytes
+	xor	    r12, r12, 3
 	ldh.ab	r4, [r1, 2]
 	sth.ab	r4, [r3, 2]
 1:
-	bbit0.d	r2, 0, @1f
-	asl	r12, r12, 1
+	bbit0.d	r2, 0, @1f		; is b0 set? then copy 1 byte
+	asl	    r12, r12, 1
 	ldb.ab	r4, [r1, 1]
 	stb.ab	r4, [r3, 1]
+
+; Interpreting bits (b4,b3) [1] and how they correlate to branch index:
+;
+; (b4,b3) | bytes to copy | branch index
+; --------+---------------+-------------
+;   00b   |       0       |   3 (11b)
+;   01b   |       8       |   2 (10b)
+;   10b   |      16       |   1 (01b)
+;   11b   |      24       |   0 (00b)
+;
+; To go from (b4,b3) to branch index, the bits must be flipped.
+; In other words, they must be XORed with 11b [2].
+;
+; Last but not least, "bi" jumps at boundaries of 4. We need to double
+; the index to jump 8 bytes [3].
+;
+; Hence, the 3 operations for calculating the branch index that are spread
+; in "bbit0" delay slots:
+;
+;	lsr	    r12, r2,  3    [1]
+;	xor	    r12, r12, 3    [2]
+;	asl	    r12, r12, 1    [3]
 1:
-	bi	[r12]
+	bi	    [r12]
 	LD64.ab	r4, [r1, 8]
 	ST64.ab	r4, [r3, 8]
 	LD64.ab	r4, [r1, 8]
@@ -117,8 +138,6 @@ ENTRY (memmove)
 	ST64.ab	r4, [r3, 8]
 
 	j_s	[blink]
-
-
 
 ENDFUNC (memmove)
 

--- a/newlib/libc/machine/arc64/memmove.S
+++ b/newlib/libc/machine/arc64/memmove.S
@@ -4,11 +4,8 @@
 ; r1 const void* src
 ; r2 size_t count
 
-<<<<<<< HEAD
 #if defined (__ARC64_ARCH64__)
 
-=======
->>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 ENTRY (memmove)
 	; If the source plus count is greater than the destination
 	; There is an overlap, and a backwards copy must be performed
@@ -17,16 +14,11 @@ ENTRY (memmove)
 	
 	; Dst is less than src, can safely perform normal memcpy
 	BRLO.d		r0, r1, @.L_normal_memcpy
-<<<<<<< HEAD
 	addl		r4, r1, r2
-=======
-	ADDP		r4, r1, r2
->>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 
 	BRLO.d		r4, r0, @.L_normal_memcpy
 	; Only relevant when not taking the branch, but might as well
 	; use the delay slot (after the branch, this will be redone
-<<<<<<< HEAD
 	addl	r3, r0, r2
 ; Backwards search
 ; The only thing that changes between memcpy and memmove is copy direction
@@ -38,22 +30,6 @@ ENTRY (memmove)
 	addl	r1, r1, r2
 	bmsk_s	r2, r2, 4
 
-=======
-	ADDP	r3, r0, r2
-
-	;BRGT.d	r0, r4, @.L_backwards_search
-
-; Backwards search
-; The only thing that changes between memcpy and memmove is copy direction
-; in case the dest and src address memory locations overlap
-; For a scratch implementation, have separate code for incremental and decremental copies	
-	; Set both r0 and r1 to point to the end of eahc memory location
-	ADDP	r1, r1, r2
-	bmsk_s	r2, r2, 4
-
-; Take care of the last 31 bytes
-.L_B_write_31_bytes:
->>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 	bbit0.d	r2, 0, @1f
 	lsr	r11, r2, 3
 	ldb.aw	r4, [r1, -1]
@@ -77,17 +53,9 @@ ENTRY (memmove)
 	LD64.aw	r4, [r1, -8]
 	ST64.aw	r4, [r3, -8]
 
-<<<<<<< HEAD
 	jeq	[blink]
 
 .L_write_backwards_32_bytes:			; Take care of 32 byte chunks
-=======
-; Do we have more than 32 bytes to take care of?
-	jeq	[blink]
-
-; Only take care of the 32 byte chunks at the end
-.L_B_write_32_bytes:
->>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 	LD64.aw	r4, [r1, -8]
 	LD64.aw	r6, [r1, -8]
 	LD64.aw	r8, [r1, -8]
@@ -95,7 +63,6 @@ ENTRY (memmove)
 	ST64.aw	r4, [r3, -8]
 	ST64.aw	r6, [r3, -8]
 	ST64.aw	r8, [r3, -8]
-<<<<<<< HEAD
 	dbnz.d	r12, @.L_write_backwards_32_bytes
 	ST64.aw	r10, [r3, -8]
     
@@ -107,23 +74,6 @@ ENTRY (memmove)
 	beq.d	@.L_write_forwards_31_bytes
 	MOVP	r3, r0			; do not clobber the "dest"
 .L_write_forwards_32_bytes:			; Take care of 32 byte chunks
-=======
-	dbnz.d	r12, @.L_B_write_32_bytes
-	ST64.aw	r10, [r3, -8]
-
-	j_s	[blink]
-
-
-; Normal memcpy
-.L_normal_memcpy:
-
-	; Flags were set by LSRP.f, meaning it will jump if
-	; there are no 32 byte chunks
-	beq.d	@.L_F_write_31_bytes
-	MOVP	r3, r0			; do not clobber the "dest"
-
-.L_F_write_32_bytes:
->>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 	LD64.ab	r4, [r1, +8]
 	LD64.ab	r6, [r1, +8]
 	LD64.ab	r8, [r1, +8]
@@ -131,7 +81,6 @@ ENTRY (memmove)
 	ST64.ab	r4, [r3, +8]
 	ST64.ab	r6, [r3, +8]
 	ST64.ab	r8, [r3, +8]
-<<<<<<< HEAD
 	dbnz.d	r12, @.L_write_forwards_32_bytes
 	ST64.ab	r10, [r3, +8]	; Shove store in delay slot
 	bmsk_s	r2, r2, 4		; From now on, we only care for the remainder % 32
@@ -181,29 +130,6 @@ ENTRY (memmove)
 ;	asl	    r12, r12, 1    [3]
 1:
 	bi	    [r12]
-=======
-	dbnz.d	r12, @.L_F_write_32_bytes
-	ST64.ab	r10, [r3, +8]
-	bmsk_s	r2, r2, 4
-
-.L_F_write_31_bytes:
-	bbit0.d	r2, 2, @1f
-	lsr	r12, r2, 3
-	ld.ab	r4, [r1, 4]
-	st.ab	r4, [r3, 4]
-1:
-	bbit0.d	r2, 1, @1f
-	xor	r12, r12, 3
-	ldh.ab	r4, [r1, 2]
-	sth.ab	r4, [r3, 2]
-1:
-	bbit0.d	r2, 0, @1f
-	asl	r12, r12, 1
-	ldb.ab	r4, [r1, 1]
-	stb.ab	r4, [r3, 1]
-1:
-	bi	[r12]
->>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 	LD64.ab	r4, [r1, 8]
 	ST64.ab	r4, [r3, 8]
 	LD64.ab	r4, [r1, 8]
@@ -213,13 +139,7 @@ ENTRY (memmove)
 
 	j_s	[blink]
 
-<<<<<<< HEAD
 ENDFUNC (memmove)
 
 #endif
-=======
-
-
-ENDFUNC (memmove)
->>>>>>> 79d05417d (Added tested implementation of memmove based on current implementation of memcpy. Need to compare efficiency/speed with default implementation)
 

--- a/newlib/libc/machine/arc64/memmove.S
+++ b/newlib/libc/machine/arc64/memmove.S
@@ -1,0 +1,126 @@
+#include <sys/asm.h>
+
+; r0 void* dest
+; r1 const void* src
+; r2 size_t count
+
+#if defined (__ARC64_ARCH64__)
+
+ENTRY (memmove)
+	; If the source plus count is greater than the destination
+	; There is an overlap, and a backwards copy must be performed
+	;add		r4, r1, r2
+	LSRP.f	r12, r2, 5		; counter for 32-byte chunks
+	
+	; Dst is less than src, can safely perform normal memcpy
+	BRLO.d		r0, r1, @.L_normal_memcpy
+	addl		r4, r1, r2
+
+	BRLO.d		r4, r0, @.L_normal_memcpy
+	; Only relevant when not taking the branch, but might as well
+	; use the delay slot (after the branch, this will be redone
+	addl	r3, r0, r2
+
+; Backwards search
+; The only thing that changes between memcpy and memmove is copy direction
+; in case the dest and src address memory locations overlap
+; For a scratch implementation, have separate code for incremental and decremental copies	
+	; Set both r0 and r1 to point to the end of eahc memory location
+	addl	r1, r1, r2
+	bmsk_s	r2, r2, 4
+
+; Take care of the last 31 bytes
+.L_B_write_31_bytes:
+	bbit0.d	r2, 0, @1f
+	lsr	r11, r2, 3
+	ldb.aw	r4, [r1, -1]
+	stb.aw	r4, [r3, -1]
+1:
+	bbit0.d	r2, 1, @1f
+	xor	r11, r11, 3
+	ldh.aw	r4, [r1, -2]
+	sth.aw	r4, [r3, -2]
+1:
+	bbit0.d	r2, 2, @1f
+	asl	r11, r11, 1
+	ld.aw	r4, [r1, -4]
+	st.aw	r4, [r3, -4]
+1:
+	bi	[r11]
+	LD64.aw	r4, [r1, -8]
+	ST64.aw	r4, [r3, -8]
+	LD64.aw	r4, [r1, -8]
+	ST64.aw	r4, [r3, -8]
+	LD64.aw	r4, [r1, -8]
+	ST64.aw	r4, [r3, -8]
+
+; Do we have more than 32 bytes to take care of?
+	jeq	[blink]
+
+; Only take care of the 32 byte chunks at the end
+.L_B_write_32_bytes:
+	LD64.aw	r4, [r1, -8]
+	LD64.aw	r6, [r1, -8]
+	LD64.aw	r8, [r1, -8]
+	LD64.aw	r10,[r1, -8]
+	ST64.aw	r4, [r3, -8]
+	ST64.aw	r6, [r3, -8]
+	ST64.aw	r8, [r3, -8]
+	dbnz.d	r12, @.L_B_write_32_bytes
+	ST64.aw	r10, [r3, -8]
+
+	j_s	[blink]
+
+
+; Normal memcpy
+.L_normal_memcpy:
+
+	; Flags were set by LSRP.f, meaning it will jump if
+	; there are no 32 byte chunks
+	beq.d	@.L_F_write_31_bytes
+	MOVP	r3, r0			; do not clobber the "dest"
+
+.L_F_write_32_bytes:
+	LD64.ab	r4, [r1, +8]
+	LD64.ab	r6, [r1, +8]
+	LD64.ab	r8, [r1, +8]
+	LD64.ab	r10,[r1, +8]
+	ST64.ab	r4, [r3, +8]
+	ST64.ab	r6, [r3, +8]
+	ST64.ab	r8, [r3, +8]
+	dbnz.d	r12, @.L_F_write_32_bytes
+	ST64.ab	r10, [r3, +8]
+	bmsk_s	r2, r2, 4
+
+.L_F_write_31_bytes:
+	bbit0.d	r2, 2, @1f
+	lsr	r12, r2, 3
+	ld.ab	r4, [r1, 4]
+	st.ab	r4, [r3, 4]
+1:
+	bbit0.d	r2, 1, @1f
+	xor	r12, r12, 3
+	ldh.ab	r4, [r1, 2]
+	sth.ab	r4, [r3, 2]
+1:
+	bbit0.d	r2, 0, @1f
+	asl	r12, r12, 1
+	ldb.ab	r4, [r1, 1]
+	stb.ab	r4, [r3, 1]
+1:
+	bi	[r12]
+	LD64.ab	r4, [r1, 8]
+	ST64.ab	r4, [r3, 8]
+	LD64.ab	r4, [r1, 8]
+	ST64.ab	r4, [r3, 8]
+	LD64.ab	r4, [r1, 8]
+	ST64.ab	r4, [r3, 8]
+
+	j_s	[blink]
+
+
+
+ENDFUNC (memmove)
+
+#endif
+

--- a/newlib/libc/machine/arc64/memmove.S
+++ b/newlib/libc/machine/arc64/memmove.S
@@ -10,17 +10,17 @@
 
 ENTRY (memmove)
 
-; If the source plus count is greater than the destination
-; There is an overlap, and a backwards copy must be performed
-	lsr.f	r11, r2, 4		; counter for 16-byte chunks
-	
-; Dst is less than src, can safely perform normal memcpy
-	BRLO.d	r0, r1, @.L_normal_memcpy
+; If the destination is greater than the source
+	cmp	r0, r1
 	ADDP	r4, r1, r2
+; or if the source plus count is smaller than the destination
+	cmp.eq r4, r0
 
-	BRLO.d	r4, r0, @.L_normal_memcpy
-; Only relevant when not taking the branch, but might as well
-; use the delay slot (after the branch, this will be redone
+; We can safely perform a normal memcpy. Otherwise, we need to perform it
+; backwards
+	blo.d	@.L_normal_memcpy
+	lsr.f	r11, r2, 4		; counter for 16-byte chunks
+
 	ADDP	r3, r0, r2
 
 ; Backwards search
@@ -111,25 +111,26 @@ ENDFUNC (memmove)
 #else
 
 ENTRY (memmove)
-; If the source plus count is greater than the destination
-; There is an overlap, and a backwards copy must be performed
-	LSRP.f	r12, r2, 5		; counter for 32-byte chunks
-	
-; Dst is less than src, can safely perform normal memcpy
-	BRLO.d	r0, r1, @.L_normal_memcpy
+; If the destination is greater than the source
+	cmp	r0, r1
 	ADDP	r4, r1, r2
+; or if the source plus count is smaller than the destination
+	cmp.eq r4, r0
 
-	BRLO.d	r4, r0, @.L_normal_memcpy
-; Only relevant when not taking the branch, but might as well
-; use the delay slot (after the branch, this will be redone
+; We can safely perform a normal memcpy. Otherwise, we need to perform it
+; backwards
+	blo.d	@.L_normal_memcpy
+	LSRP.f	r12, r2, 5		; counter for 32-byte chunks
+
 	ADDP	r3, r0, r2
+
 ; Backwards search
 ; The only thing that changes between memcpy and memmove is copy direction
 ; in case the dest and src address memory locations overlap
 ; More detailed information is in the forwards copy and at the end of
 ; this document
 
-; Set both r0 and r1 to point to the end of eahc memory location
+; Set both r0 and r1 to point to the end of each memory location
 	ADDP	r1, r1, r2
 	bmsk_s	r2, r2, 4
 

--- a/newlib/libc/machine/arc64/memmove.S
+++ b/newlib/libc/machine/arc64/memmove.S
@@ -4,7 +4,12 @@
 ; r1 const void* src
 ; r2 size_t count
 
-#if defined (__ARC64_ARCH64__)
+
+
+; Using 128-bit memory operations
+
+
+; The 64-bit crunching implementation.
 
 ENTRY (memmove)
 	; If the source plus count is greater than the destination
@@ -56,6 +61,17 @@ ENTRY (memmove)
 	jeq	[blink]
 
 .L_write_backwards_32_bytes:			; Take care of 32 byte chunks
+#if defined (__ARC64_M128__)
+
+	lddl.aw	r4r5, [r1, -16]
+	lddl.aw	r6r7, [r1, -16]
+
+	stdl.aw	r4r5, [r3, -16]
+	stdl.aw	r6r7, [r3, -16]
+	dbnz	r12, @.L_write_backwards_32_bytes
+
+#elif defined (__ARC64_ARCH64__)
+
 	LD64.aw	r4, [r1, -8]
 	LD64.aw	r6, [r1, -8]
 	LD64.aw	r8, [r1, -8]
@@ -65,7 +81,11 @@ ENTRY (memmove)
 	ST64.aw	r8, [r3, -8]
 	dbnz.d	r12, @.L_write_backwards_32_bytes
 	ST64.aw	r10, [r3, -8]
-    
+
+#else
+# error Unknown configuration
+#endif
+
 	j_s	[blink]
 
 ; Normal memcpy
@@ -74,6 +94,17 @@ ENTRY (memmove)
 	beq.d	@.L_write_forwards_31_bytes
 	MOVP	r3, r0			; do not clobber the "dest"
 .L_write_forwards_32_bytes:			; Take care of 32 byte chunks
+#if defined (__ARC64_M128__)
+
+	lddl.ab	r4r5, [r1, +16]
+	lddl.ab	r6r7, [r1, +16]
+
+	stdl.ab	r4r5, [r3, +16]
+	stdl.ab	r6r7, [r3, +16]
+	dbnz	r12, @.L_write_forwards_32_bytes
+
+#elif defined (__ARC64_ARCH64__)
+
 	LD64.ab	r4, [r1, +8]
 	LD64.ab	r6, [r1, +8]
 	LD64.ab	r8, [r1, +8]
@@ -83,6 +114,12 @@ ENTRY (memmove)
 	ST64.ab	r8, [r3, +8]
 	dbnz.d	r12, @.L_write_forwards_32_bytes
 	ST64.ab	r10, [r3, +8]	; Shove store in delay slot
+
+#else
+# error Unknown configuration
+#endif
+
+
 	bmsk_s	r2, r2, 4		; From now on, we only care for the remainder % 32
 
 
@@ -141,5 +178,4 @@ ENTRY (memmove)
 
 ENDFUNC (memmove)
 
-#endif
 

--- a/newlib/libc/machine/arc64/sys/asm.h
+++ b/newlib/libc/machine/arc64/sys/asm.h
@@ -35,21 +35,23 @@
  * Macros to handle different pointer/register sizes for 32/64-bit code
  */
 #if defined (__ARC64_ARCH32__)
-# define ST64  std
-# define LD64  ldd
-# define MOVP  mov
-# define LSRP  lsr
-# define REG_SZ 4
-# define REG_ST st
-# define REG_LD ld
+# define ST64		std
+# define LD64		ldd
+# define MOVP		mov
+# define LSRP		lsr
+# define ADDP		add
+# define REG_SZ		4
+# define REG_ST		st
+# define REG_LD		ld
 #elif defined (__ARC64_ARCH64__)
-# define ST64  stl
-# define LD64  ldl
-# define MOVP  movl
-# define LSRP  lsrl
-# define REG_SZ 8
-# define REG_ST stl
-# define REG_LD ldl
+# define ST64		stl
+# define LD64		ldl
+# define MOVP		movl
+# define LSRP		lsrl
+# define ADDP		addl
+# define REG_SZ		8
+# define REG_ST		stl
+# define REG_LD		ldl
 #else
 # error Please use either 32-bit or 64-bit version of arc64 compiler
 #endif


### PR DESCRIPTION
Created assembly version of memmove with the objective of focusing on speed for larger amounts of memory
Used measure of speed is instruction count from NSIM, via CPU counters.
Measurements against compiler generated code suggest a decrease in instruction count of ~90% for big memory sizes (200 bytes) and ~30% for smaller ones (14 bytes).
32-bit and 128-bit implementations have slightly smaller, and bigger improvements (respectively)
Newlib dejaGNU tests pass with success