### PR TITLE
Added -fno-builtin flag as an additional flag to the testsuites overr…

### DIFF
--- a/newlib/testsuite/lib/newlib.exp
+++ b/newlib/testsuite/lib/newlib.exp
@@ -60,6 +60,7 @@ proc newlib_target_compile { source dest type options } {
     verbose "In newlib_target_compile...\n"
 
     lappend options "libs=-I$srcdir/include"
+    lappend options "additional_flags=-fno-builtin"
     verbose "srcdir is $srcdir"
 	
     if {[target_info needs_status_wrapper] != "" && \


### PR DESCRIPTION
Added -fno-builtin flag to compilation flags for the test generation, so the compiler does not use the host builtin system libraries to replace calls to the guest system libraries which are being tested.