### PR TITLE
arc, arc64: Remove .file directive from .S files

### DIFF
--- a/libgloss/arc/crt0.S
+++ b/libgloss/arc/crt0.S
@@ -55,7 +55,6 @@
 #define __ARCHS__ 1
 #endif
 
-	.file	"crt0.S"
 	.extern main
 
 #if defined (__ARCEM__) || defined (__ARCHS__)

--- a/libgloss/arc/dw_uart/arc/arc_exc_asm.S
+++ b/libgloss/arc/dw_uart/arc/arc_exc_asm.S
@@ -63,8 +63,6 @@
 #include "../inc/arc/arc.h"
 #include "../inc/arc/arc_asm_common.h"
 
-	.file "arc_exc_asm.S"
-
 /* entry for cpu exception handling */
 	.text
 	.global exc_entry_cpu

--- a/libgloss/arc64/crt0.S
+++ b/libgloss/arc64/crt0.S
@@ -47,7 +47,6 @@
 	.endif
 	.endm
 
-	.file	"crt0.S"
 	.extern main
 
 	.section .text.__startup, "ax", @progbits

--- a/newlib/libc/machine/arc/setjmp.S
+++ b/newlib/libc/machine/arc/setjmp.S
@@ -32,8 +32,6 @@
    these are the stack mappings for the registers
    as stored in the ABI for ARC */
 
-       .file "setjmp.S"
-
 ABIr13	= 0
 ABIr14	= ABIr13 + 4
 ABIr15	= ABIr14 + 4

--- a/newlib/libc/machine/arc64/setjmp.S
+++ b/newlib/libc/machine/arc64/setjmp.S
@@ -34,8 +34,6 @@
    these are the stack mappings for the registers
    as stored in the ABI for ARC */
 
-       .file "setjmp.S"
-
 ABIr14	= 0
 ABIr15	= ABIr14 + REG_SZ
 ABIr16	= ABIr15 + REG_SZ


### PR DESCRIPTION
This PR fixes this issue: https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/344

Assembler for ARCv2 always extends the name provided by `.file` directive to an absolute form.

On ARCv3 targets `.file` directive forces assembler to put a provided string to `DW_AT_name` field as is without extending to an absolute path. Then GDB cannot find source files because of it.

The best way to fix this issue is just delete lines with `.file` directive in `.S` files and let the compiler to decide what `DW_AT_name` must contain. Particularly, the compiler fills this filed by an absolute path to a `.S` file because only absolute paths are used in toolchain's build process.