### PR TITLE
arc: fix typo in libdw_uart sources

### DIFF
--- a/libgloss/arc/Makefile.inc
+++ b/libgloss/arc/Makefile.inc
@@ -43,7 +43,7 @@ multilibtool_LIBRARIES += %D%/libdw_uart.a
 	%D%/write.c \
 	%D%/read.c \
 	%D%/stub.c \
-	%D%/sbrk.c
+	%D%/sbrk.c \
 	%D%/dw_uart/arc/arc_exc_asm.S \
         %D%/dw_uart/arc/arc_exception.S \
         %D%/dw_uart/board/board.c \


### PR DESCRIPTION
This PR fixes this issue: https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/529. Can you please also regenerate `Makefile.in` properly and push? I am not sure that I can do it correctly.