### PR TITLE
_fstat: Change stat to fstat call.

### DIFF
--- a/libgloss/arc/nsim-syscalls.c
+++ b/libgloss/arc/nsim-syscalls.c
@@ -206,7 +206,7 @@ _fstat (int fd, struct stat *buf)
 {
   struct nsim_stat nsim_stat;
   long __res;
-  _naked_syscall2 (__res, stat, fd, &nsim_stat)
+  _naked_syscall2 (__res, fstat, fd, &nsim_stat)
   translate_stat (&nsim_stat, buf);
   return __res;
 }

--- a/libgloss/arc64/nsim-syscall.c
+++ b/libgloss/arc64/nsim-syscall.c
@@ -208,7 +208,7 @@ _fstat (int fd, struct stat *buf)
 {
   struct nsim_stat nsim_stat;
   long __res;
-  _naked_syscall2 (__res, stat, fd, &nsim_stat)
+  _naked_syscall2 (__res, fstat, fd, &nsim_stat)
   translate_stat (&nsim_stat, buf);
   return __res;
 }


### PR DESCRIPTION
Modified the fstat call from stat to fstat
accordingly to semi-hosting syscall.