### PR TITLE
Add missing commits and fix the linker script of boards

### DIFF
--- a/libgloss/arc/arcv2elf-common.ld
+++ b/libgloss/arc/arcv2elf-common.ld
@@ -189,7 +189,7 @@ SECTIONS
   .stab.exclstr  0 : { *(.stab.exclstr) }
   .stab.index    0 : { *(.stab.index) }
   .stab.indexstr 0 : { *(.stab.indexstr) }
-  .comment 0 (INFO) : { *(.comment); LINKER_VERSION; }
+  .comment 0 (INFO) : { *(.comment) }
   .gnu.build.attributes : { *(.gnu.build.attributes .gnu.build.attributes.*) }
   /* DWARF debug sections.
      Symbols in the DWARF debugging sections are relative to the beginning

--- a/libgloss/arc/nsim-syscalls.c
+++ b/libgloss/arc/nsim-syscalls.c
@@ -206,7 +206,7 @@ _fstat (int fd, struct stat *buf)
 {
   struct nsim_stat nsim_stat;
   long __res;
-  _naked_syscall2 (__res, stat, fd, &nsim_stat)
+  _naked_syscall2 (__res, fstat, fd, &nsim_stat)
   translate_stat (&nsim_stat, buf);
   return __res;
 }

--- a/libgloss/arc64/nsim-syscall.c
+++ b/libgloss/arc64/nsim-syscall.c
@@ -208,7 +208,7 @@ _fstat (int fd, struct stat *buf)
 {
   struct nsim_stat nsim_stat;
   long __res;
-  _naked_syscall2 (__res, stat, fd, &nsim_stat)
+  _naked_syscall2 (__res, fstat, fd, &nsim_stat)
   translate_stat (&nsim_stat, buf);
   return __res;
 }


### PR DESCRIPTION
Don't use `LINKER_VERSION` variable in the linker script - it cannot be recognized by older Binutils. Also, add missing commits from `arc64` branch.