### PR TITLE
libgloss: riscv: define init_array-related symbols for ARCV

### DIFF
--- a/libgloss/riscv/arcv.ld
+++ b/libgloss/riscv/arcv.ld
@@ -66,6 +66,16 @@ SECTIONS
   } > DCCM
   _edata = .; PROVIDE(edata = .);
 
+  PROVIDE (__preinit_array_start = .);
+  .preinit_array  : { *(.preinit_array) } >DCCM
+  PROVIDE (__preinit_array_end = .);
+  PROVIDE (__init_array_start = .);
+  .init_array     : { *(.init_array) } >DCCM
+  PROVIDE (__init_array_end = .);
+  PROVIDE (__fini_array_start = .);
+  .fini_array     : { *(.fini_array) } >DCCM
+  PROVIDE (__fini_array_end = .);
+
   /* bss segment */
   __bss_start = .;
   .sbss : {


### PR DESCRIPTION
Since the newlib implementation of the __libc_init_array() function requires the {preinit,init,fini}_array sections and the corresponding boundary symbols to exist, provide those in arcv.ld in order to be able to use GCC constructor/destructor functions.

This allows us to remove explicit calls to e.g. the init_semihosting() function in user programs.