### PR TITLE
arcv.specs: Remove the use of custom linker script.

### DIFF
--- a/libgloss/riscv/arcv.specs
+++ b/libgloss/riscv/arcv.specs
@@ -1,7 +1,2 @@
-%rename link	old_link
-
-*link:
--T arcv.ld%s %(old_link)
-
 *startfile:
 arcv-crt0%O%s crtbegin%O%s


### PR DESCRIPTION
Modified the arcv.specs file and removed the use
of custom linker script.