### PR TITLE
Align stack on 16-bytes boundary

### DIFF
--- a/libgloss/Makefile.in
+++ b/libgloss/Makefile.in
@@ -346,9 +346,9 @@ multilibtool_PROGRAMS = $(am__EXEEXT_7)
 @CONFIG_RISCV_TRUE@	riscv/nano.specs \
 @CONFIG_RISCV_TRUE@	riscv/sim.specs \
 @CONFIG_RISCV_TRUE@	riscv/semihost.specs \
-@CONFIG_RISCV_TRUE@     riscv/arcv.specs \
-@CONFIG_RISCV_TRUE@     riscv/arcv-crt0.o \
-@CONFIG_RISCV_TRUE@     riscv/arcv.ld \
+@CONFIG_RISCV_TRUE@	riscv/arcv.specs \
+@CONFIG_RISCV_TRUE@	riscv/arcv-crt0.o \
+@CONFIG_RISCV_TRUE@	riscv/arcv.ld \
 @CONFIG_RISCV_TRUE@	riscv/crt0.o
 
 @CONFIG_RISCV_TRUE@am__append_98 = riscv/libgloss.a riscv/libsim.a \

--- a/libgloss/riscv/arcv.ld
+++ b/libgloss/riscv/arcv.ld
@@ -94,6 +94,9 @@ SECTIONS
   /* End of uninitalized data segement */
   _end = .; PROVIDE (end = .);
 
-  __stack_pointer$ = (ORIGIN (DCCM) + LENGTH (DCCM) - 1) & -4;
+  /* It's necessary to align stack on 16-bytes boundary since it's a
+     maximum possible alignment for RISC-V targets according to
+     RISC-V ABI.  */
+  __stack_pointer$ = (ORIGIN (DCCM) + LENGTH (DCCM) - 1) & -16;
 }
 


### PR DESCRIPTION
The linker script for ARC-V aligns the stack on 4-bytes boundary and it leads to undefined behaviour while pushing argument to the stack.

It's necessary to align it on 16-bytes boundary since it's a maximum possible alignment for RISC-V targets according to RISC-V ABI.