### PR TITLE
libgloss: riscv: Use SEMIHOST_exit_extended in semihosting

### DIFF
--- a/libgloss/riscv/semihost-sys_exit.c
+++ b/libgloss/riscv/semihost-sys_exit.c
@@ -11,13 +11,15 @@
 void
 _exit (int exit_status)
 {
-#if __riscv_xlen == 32
-  syscall_errno (SEMIHOST_exit, (long *) ADP_Stopped_ApplicationExit);
-#else
-  /* The semihosting exit operation only allows 64-bit targets to report the
-     exit code.  */
+  /* SYS_EXIT_EXTENDED semihosting call allows exiting with an exit code both
+     on 32-bit and 64-bit targets. However, it's not available in the first
+     version of the semihosting specification. Since the first version is
+     pretty old, it may be assumed that semihosting v2 is available and
+     SYS_EXIT_EXTENDED may be used.
+
+     TODO: Implement a mechanism for detecting semihosting features like it's
+     done in libsemihosting for ARM.  */
   long data_block[] = {ADP_Stopped_ApplicationExit, exit_status};
-  syscall_errno (SEMIHOST_exit, data_block);
-#endif
+  syscall_errno (SEMIHOST_exit_extended, data_block);
   while (1);
 }


### PR DESCRIPTION
`SYS_EXIT_EXTENDED` semihosting call allows exiting with an exit code both on 32-bit and 64-bit targets. However, it's not available in the first version of the semihosting specification. Since the first version is pretty old, it may be assumed that semihosting v2 is available and `SYS_EXIT_EXTENDED` may be used.