### PR TITLE
Add support of semihosting command line arguments

### DIFF
--- a/libgloss/riscv/arcv-crt0.S
+++ b/libgloss/riscv/arcv-crt0.S
@@ -40,6 +40,16 @@ _start:
 	addi  sp, sp, %pcrel_lo(1b)
 	.option pop
 
+	# Initialize FPU if it is presented. 8192 stands for 1 << 13 bit offset -
+	# the first bit of FS[1:0] field of mstatus CSR.
+#ifdef __riscv_flen
+	csrr    t0, mstatus
+	li      t1, 8192
+	or      t0, t1, t0
+	csrw    mstatus, t0
+	csrwi   fcsr, 0
+#endif
+
 	# Clear the bss segment
 	la      a0, __bss_start
 	la      a2, _end

--- a/libgloss/riscv/arcv-crt0.S
+++ b/libgloss/riscv/arcv-crt0.S
@@ -1,4 +1,4 @@
-/* Copyright (c) 2023  Synopsys. All rights reserved.
+/* Copyright (c) 2024  Synopsys. All rights reserved.
 
    This copyrighted material is made available to anyone wishing to use,
    modify, copy, or redistribute it subject to the terms and conditions
@@ -24,7 +24,7 @@ _start:
 	.cfi_startproc
 
 	# Initialize global pointer.  This is done with relaxation
-        # disabled, not to end up with only "addi gp,gp,0"
+	# disabled, not to end up with only "addi gp,gp,0"
 	.option push
 	.option norelax
 1:
@@ -64,7 +64,9 @@ _start:
 
 	lw      a0, 0(sp)                  # a0 = argc
 	addi    a1, sp, __SIZEOF_POINTER__ # a1 = argv
-	li      a2, 0                      # a2 = envp = NULL
+	slli    a2, a0, 1 + __SIZEOF_POINTER__ >> 2
+	addi    a2, a2, __SIZEOF_POINTER__
+	add     a2, a2, a1                 # a2 = envp
 	call    main
 	tail    exit
 	.cfi_endproc

--- a/libgloss/riscv/arcv-crt0.S
+++ b/libgloss/riscv/arcv-crt0.S
@@ -72,11 +72,25 @@ _start:
 #endif
 	call    __libc_init_array       # Run global initialization functions
 
+	# Get arguments from custom symbols if they are defined. Otherwise,
+	# get them from the stack.
+	.weak _argc
+	.weak _argv
+	la      a0, _argc
+	beqz    a0, .Largs_from_stack
+	la      a1, _argv
+	beqz    a1, .Largs_from_stack
+	lw      a0, 0(a0)
+	jal     x0, .Lmain
+
+.Largs_from_stack:
 	lw      a0, 0(sp)                  # a0 = argc
 	addi    a1, sp, __SIZEOF_POINTER__ # a1 = argv
 	slli    a2, a0, 1 + __SIZEOF_POINTER__ >> 2
 	addi    a2, a2, __SIZEOF_POINTER__
 	add     a2, a2, a1                 # a2 = envp
+
+.Lmain:
 	call    main
 	tail    exit
 	.cfi_endproc

--- a/libgloss/riscv/crt0.S
+++ b/libgloss/riscv/crt0.S
@@ -59,11 +59,25 @@ _start:
 #endif
   call    __libc_init_array       # Run global initialization functions
 
+  # Get arguments from custom symbols if they are defined. Otherwise,
+  # get them from the stack.
+  .weak _argc
+  .weak _argv
+  la      a0, _argc
+  beqz    a0, .Largs_from_stack
+  la      a1, _argv
+  beqz    a1, .Largs_from_stack
+  lw      a0, 0(a0)
+  jal     x0, .Lmain
+
+.Largs_from_stack:
   lw      a0, 0(sp)                  # a0 = argc
   addi    a1, sp, __SIZEOF_POINTER__ # a1 = argv
   slli    a2, a0, 1 + __SIZEOF_POINTER__ >> 2
   addi    a2, a2, __SIZEOF_POINTER__
   add     a2, a2, a1                 # a2 = envp
+
+.Lmain:
   call    main
   tail    exit
   .size  _start, .-_start

--- a/libgloss/riscv/semihost-sys_fdtable.c
+++ b/libgloss/riscv/semihost-sys_fdtable.c
@@ -2,10 +2,14 @@
  * Copyright (C) 2020 Embecosm Limited
  * SPDX-License-Identifier: BSD-2-Clause
  */
-#include "semihost_fdtable.h"
 #include <errno.h>
 #include <fcntl.h>
 #include <unistd.h>
+#include <string.h>
+#include <ctype.h>
+#include <machine/syscall.h>
+#include "semihost_syscall.h"
+#include "semihost_fdtable.h"
 
 #ifndef RISCV_MAX_OPEN_FILES
 #define RISCV_MAX_OPEN_FILES 16
@@ -21,8 +25,8 @@ static struct fdentry fdtable[RISCV_MAX_OPEN_FILES];
 
 /* Initialize fdtable.  A handle of -1 denotes an empty entry.  */
 
-void __attribute__ ((constructor))
-init_semihosting ()
+static void
+init_semihosting_fdtable ()
 {
   int i;
 
@@ -45,6 +49,75 @@ init_semihosting ()
   i = _open (":tt", O_WRONLY|O_CREAT|O_APPEND);
   fdtable[STDERR_FILENO].handle = fdtable[i].handle;
   fdtable[STDERR_FILENO].pos = 0;
+}
+
+/* Initialize command line arguments. We must do it here because symbols in
+   this file are referenced in libc and the linker always pushes an
+   object file for this source file to the final binary. Anyway, it would be
+   wise to do all semihosting initializations in one place.  */
+
+#ifndef RISCV_MAX_CMDLINE_LENGTH
+#define RISCV_MAX_CMDLINE_LENGTH 1024
+#endif
+
+#ifndef RISCV_MAX_ARGV_LENGTH
+#define RISCV_MAX_ARGV_LENGTH 64
+#endif
+
+int _argc = 0;
+char *_argv[RISCV_MAX_ARGV_LENGTH] = { NULL };
+
+static void
+init_semihosting_args ()
+{
+  static char cmdline[RISCV_MAX_CMDLINE_LENGTH];
+  long args[2] = { (long) cmdline, sizeof(cmdline) };
+  long ret = syscall_errno(SEMIHOST_get_cmdline, args);
+  char *ptr;
+
+  /* Exit early if semihosting call failed or NULL buffer is returned.  */
+  if (ret != 0 || (char *) args[0] == NULL) {
+    return;
+  }
+
+  /* If a semihosting implementation returns another pointer to a command
+     line buffer and does not reuse our own one then copy that explicitly.  */
+  if (args[0] != (long) cmdline) {
+    strcpy(cmdline, (const char *) args[0]);
+  }
+
+  ptr = cmdline;
+  while (_argc < RISCV_MAX_ARGV_LENGTH - 1) {
+    /* Skip leading whitespace characters.  */
+    while (isspace(*ptr))
+      ptr++;
+
+    /* Finish if the end is reached.  */
+    if (*ptr == '\0')
+      break;
+
+    /* An argument is found.  */
+    _argv[_argc++] = ptr;
+
+    /* Skip argument's characters.  */
+    while (*ptr != '\0' && !isspace(*ptr))
+      ptr++;
+
+    /* Finish if the end is reached (again).  */
+    if (*ptr == '\0')
+      break;
+
+    /* Cut out an argument in a command line.  */
+    *ptr = '\0';
+    ptr++;
+  }
+}
+
+void __attribute__ ((constructor))
+init_semihosting ()
+{
+  init_semihosting_fdtable();
+  init_semihosting_args();
 }
 
 /* Add entry to fdtable.  */


### PR DESCRIPTION
Initialize command line arguments in `libgloss/riscv/semihost-sys_fdtable.c`. We must do it there because symbols in this file are referenced in libc and the linker always pushes an object file for this source file to the final binary. Anyway, it would be wise to do all semihosting initializations in one place.