### PR TITLE
libgloss: arcv: Do not get argc, argv and argp from the stack

### DIFF
--- a/libgloss/riscv/arcv-crt0.S
+++ b/libgloss/riscv/arcv-crt0.S
@@ -77,20 +77,18 @@ _start:
 	.weak _argc
 	.weak _argv
 	la      a0, _argc
-	beqz    a0, .Largs_from_stack
+	beqz    a0, .Lempty_args
 	la      a1, _argv
-	beqz    a1, .Largs_from_stack
+	beqz    a1, .Lempty_args
 	lw      a0, 0(a0)
-	jal     x0, .Lmain
+	j       .Lmain
 
-.Largs_from_stack:
-	lw      a0, 0(sp)                  # a0 = argc
-	addi    a1, sp, __SIZEOF_POINTER__ # a1 = argv
-	slli    a2, a0, 1 + __SIZEOF_POINTER__ >> 2
-	addi    a2, a2, __SIZEOF_POINTER__
-	add     a2, a2, a1                 # a2 = envp
+.Lempty_args:
+	mv      a0, zero
+	mv      a1, zero
 
 .Lmain:
+	mv      a2, zero
 	call    main
 	tail    exit
 	.cfi_endproc


### PR DESCRIPTION
arcv-crt0.S is intended to be used for system emulation. However, crt0.S and arcv-crt0.S expect that argc, argv and argp are stored by user mode emulator on the stack - in SP, SP+4 and so on (in case of GDB/sim and qemu-riscv32/64).

Such behavior may lead to memory errors since after initialization of SP memory on SP and beyond may not exist. The solution is to set argc, argv and argp to 0 if semihosting is not used for system level emulation using arcv-crt0.S.