### PR TITLE
Preventing deleting initializers when -Wl,-gc-sections is passed to GCC

### DIFF
--- a/libgloss/riscv/arcv.ld
+++ b/libgloss/riscv/arcv.ld
@@ -67,13 +67,13 @@ SECTIONS
   _edata = .; PROVIDE(edata = .);
 
   PROVIDE (__preinit_array_start = .);
-  .preinit_array  : { *(.preinit_array) } >DCCM
+  .preinit_array  : { KEEP(*(.preinit_array)) } >DCCM
   PROVIDE (__preinit_array_end = .);
   PROVIDE (__init_array_start = .);
-  .init_array     : { *(.init_array) } >DCCM
+  .init_array     : { KEEP(*(.init_array)) } >DCCM
   PROVIDE (__init_array_end = .);
   PROVIDE (__fini_array_start = .);
-  .fini_array     : { *(.fini_array) } >DCCM
+  .fini_array     : { KEEP(*(.fini_array)) } >DCCM
   PROVIDE (__fini_array_end = .);
 
   /* bss segment */

--- a/libgloss/riscv/semihost-sys_fdtable.c
+++ b/libgloss/riscv/semihost-sys_fdtable.c
@@ -25,7 +25,7 @@ static struct fdentry fdtable[RISCV_MAX_OPEN_FILES];
 
 /* Initialize fdtable.  A handle of -1 denotes an empty entry.  */
 
-static void
+static void __attribute__ ((used))
 init_semihosting_fdtable ()
 {
   int i;
@@ -67,7 +67,7 @@ init_semihosting_fdtable ()
 int _argc = 0;
 char *_argv[RISCV_MAX_ARGV_LENGTH] = { NULL };
 
-static void
+static void __attribute__ ((used))
 init_semihosting_args ()
 {
   static char cmdline[RISCV_MAX_CMDLINE_LENGTH];
@@ -113,7 +113,7 @@ init_semihosting_args ()
   }
 }
 
-void __attribute__ ((constructor))
+void __attribute__ ((constructor, used))
 init_semihosting ()
 {
   init_semihosting_fdtable();


### PR DESCRIPTION
We need to add `used` attribute to initializers and use `KEEP` for `.*_array` sections to prevent deleting initializers when `-Wl,-gc-sections` is passed to GCC. Otherwise it would be impossible to use semihosting if it's not initializes explicitly.