### PR TITLE
Add gettimeofday system call to semihost

### DIFF
--- a/libgloss/Makefile.in
+++ b/libgloss/Makefile.in
@@ -1380,6 +1380,7 @@ riscv_libsemihost_a_LIBADD =
 @CONFIG_RISCV_TRUE@	riscv/riscv_libsemihost_a-semihost-sys_fdtable.$(OBJEXT) \
 @CONFIG_RISCV_TRUE@	riscv/riscv_libsemihost_a-semihost-sys_fstat.$(OBJEXT) \
 @CONFIG_RISCV_TRUE@	riscv/riscv_libsemihost_a-semihost-sys_ftime.$(OBJEXT) \
+@CONFIG_RISCV_TRUE@	riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.$(OBJEXT) \
 @CONFIG_RISCV_TRUE@	riscv/riscv_libsemihost_a-semihost-sys_isatty.$(OBJEXT) \
 @CONFIG_RISCV_TRUE@	riscv/riscv_libsemihost_a-semihost-sys_link.$(OBJEXT) \
 @CONFIG_RISCV_TRUE@	riscv/riscv_libsemihost_a-semihost-sys_lseek.$(OBJEXT) \
@@ -2822,6 +2823,7 @@ TEXINFO_TEX = ../texinfo/texinfo.tex
 @CONFIG_RISCV_TRUE@	riscv/semihost-sys_fdtable.c \
 @CONFIG_RISCV_TRUE@	riscv/semihost-sys_fstat.c \
 @CONFIG_RISCV_TRUE@	riscv/semihost-sys_ftime.c \
+@CONFIG_RISCV_TRUE@	riscv/semihost-sys_gettimeofday.c \
 @CONFIG_RISCV_TRUE@	riscv/semihost-sys_isatty.c \
 @CONFIG_RISCV_TRUE@	riscv/semihost-sys_link.c \
 @CONFIG_RISCV_TRUE@	riscv/semihost-sys_lseek.c \
@@ -4906,6 +4908,8 @@ riscv/riscv_libsemihost_a-semihost-sys_fstat.$(OBJEXT):  \
 	riscv/$(am__dirstamp) riscv/$(DEPDIR)/$(am__dirstamp)
 riscv/riscv_libsemihost_a-semihost-sys_ftime.$(OBJEXT):  \
 	riscv/$(am__dirstamp) riscv/$(DEPDIR)/$(am__dirstamp)
+riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.$(OBJEXT):  \
+	riscv/$(am__dirstamp) riscv/$(DEPDIR)/$(am__dirstamp)
 riscv/riscv_libsemihost_a-semihost-sys_isatty.$(OBJEXT):  \
 	riscv/$(am__dirstamp) riscv/$(DEPDIR)/$(am__dirstamp)
 riscv/riscv_libsemihost_a-semihost-sys_link.$(OBJEXT):  \
@@ -6205,6 +6209,7 @@ distclean-compile:
 @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_fdtable.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_fstat.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_ftime.Po@am__quote@
+@AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_gettimeofday.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_isatty.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_link.Po@am__quote@
 @AMDEP_TRUE@@am__include@ @am__quote@riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_lseek.Po@am__quote@
@@ -8846,6 +8851,20 @@ riscv/riscv_libsemihost_a-semihost-sys_ftime.obj: riscv/semihost-sys_ftime.c
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='riscv/semihost-sys_ftime.c' object='riscv/riscv_libsemihost_a-semihost-sys_ftime.obj' libtool=no @AMDEPBACKSLASH@
 @AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
 @am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(riscv_libsemihost_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o riscv/riscv_libsemihost_a-semihost-sys_ftime.obj `if test -f 'riscv/semihost-sys_ftime.c'; then $(CYGPATH_W) 'riscv/semihost-sys_ftime.c'; else $(CYGPATH_W) '$(srcdir)/riscv/semihost-sys_ftime.c'; fi`
+
+riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.o: riscv/semihost-sys_gettimeofday.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(riscv_libsemihost_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.o -MD -MP -MF riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_gettimeofday.Tpo -c -o riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.o `test -f 'riscv/semihost-sys_gettimeofday.c' || echo '$(srcdir)/'`riscv/semihost-sys_gettimeofday.c
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_gettimeofday.Tpo riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_gettimeofday.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='riscv/semihost-sys_gettimeofday.c' object='riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.o' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(riscv_libsemihost_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.o `test -f 'riscv/semihost-sys_gettimeofday.c' || echo '$(srcdir)/'`riscv/semihost-sys_gettimeofday.c
+
+riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.obj: riscv/semihost-sys_gettimeofday.c
+@am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(riscv_libsemihost_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.obj -MD -MP -MF riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_gettimeofday.Tpo -c -o riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.obj `if test -f 'riscv/semihost-sys_gettimeofday.c'; then $(CYGPATH_W) 'riscv/semihost-sys_gettimeofday.c'; else $(CYGPATH_W) '$(srcdir)/riscv/semihost-sys_gettimeofday.c'; fi`
+@am__fastdepCC_TRUE@	$(AM_V_at)$(am__mv) riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_gettimeofday.Tpo riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_gettimeofday.Po
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	$(AM_V_CC)source='riscv/semihost-sys_gettimeofday.c' object='riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.obj' libtool=no @AMDEPBACKSLASH@
+@AMDEP_TRUE@@am__fastdepCC_FALSE@	DEPDIR=$(DEPDIR) $(CCDEPMODE) $(depcomp) @AMDEPBACKSLASH@
+@am__fastdepCC_FALSE@	$(AM_V_CC@am__nodep@)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(riscv_libsemihost_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -c -o riscv/riscv_libsemihost_a-semihost-sys_gettimeofday.obj `if test -f 'riscv/semihost-sys_gettimeofday.c'; then $(CYGPATH_W) 'riscv/semihost-sys_gettimeofday.c'; else $(CYGPATH_W) '$(srcdir)/riscv/semihost-sys_gettimeofday.c'; fi`
 
 riscv/riscv_libsemihost_a-semihost-sys_isatty.o: riscv/semihost-sys_isatty.c
 @am__fastdepCC_TRUE@	$(AM_V_CC)$(CC) $(DEFS) $(DEFAULT_INCLUDES) $(INCLUDES) $(riscv_libsemihost_a_CPPFLAGS) $(CPPFLAGS) $(AM_CFLAGS) $(CFLAGS) -MT riscv/riscv_libsemihost_a-semihost-sys_isatty.o -MD -MP -MF riscv/$(DEPDIR)/riscv_libsemihost_a-semihost-sys_isatty.Tpo -c -o riscv/riscv_libsemihost_a-semihost-sys_isatty.o `test -f 'riscv/semihost-sys_isatty.c' || echo '$(srcdir)/'`riscv/semihost-sys_isatty.c

--- a/libgloss/riscv/Makefile.inc
+++ b/libgloss/riscv/Makefile.inc
@@ -66,6 +66,7 @@ multilibtool_LIBRARIES += %D%/libsemihost.a
 	%D%/semihost-sys_fdtable.c \
 	%D%/semihost-sys_fstat.c \
 	%D%/semihost-sys_ftime.c \
+	%D%/semihost-sys_gettimeofday.c \
 	%D%/semihost-sys_isatty.c \
 	%D%/semihost-sys_link.c \
 	%D%/semihost-sys_lseek.c \

--- a/libgloss/riscv/semihost-sys_gettimeofday.c
+++ b/libgloss/riscv/semihost-sys_gettimeofday.c
@@ -1,0 +1,54 @@
+/*
+   Copyright (c) 2024, Synopsys, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1) Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2) Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+   3) Neither the name of the Synopsys, Inc., nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include <machine/syscall.h>
+#include <time.h>
+#include <sys/time.h>
+#include "semihost_syscall.h"
+
+int
+_gettimeofday (struct timeval *tp, void *tzvp)
+{
+  struct timezone *tzp = tzvp;
+
+  if (tp != NULL)
+    {
+      tp->tv_sec = syscall_errno (SEMIHOST_time, NULL);
+      tp->tv_usec = 0;
+    }
+
+  if (tzp != NULL)
+    {
+      tzp->tz_minuteswest = 0;
+      tzp->tz_dsttime = 0;
+    }
+
+  return 0;
+}

--- a/libgloss/riscv/semihost-sys_times.c
+++ b/libgloss/riscv/semihost-sys_times.c
@@ -1,3 +1,33 @@
+/*
+   Copyright (c) 2024, Synopsys, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1) Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2) Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+   3) Neither the name of the Synopsys, Inc., nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
 #include <stdint.h>
 #include <stdbool.h>
 #include <time.h>


### PR DESCRIPTION
This system call was missing. Although `ftime` system call was presented, it's not a standard semihosting system call.