### PR TITLE
Fix linker script for ARC-V and a warning in sys_utime.c

### DIFF
--- a/libgloss/riscv/arcv.ld
+++ b/libgloss/riscv/arcv.ld
@@ -66,15 +66,28 @@ SECTIONS
   } > DCCM
   _edata = .; PROVIDE(edata = .);
 
-  PROVIDE (__preinit_array_start = .);
-  .preinit_array  : { KEEP(*(.preinit_array)) } >DCCM
-  PROVIDE (__preinit_array_end = .);
-  PROVIDE (__init_array_start = .);
-  .init_array     : { KEEP(*(.init_array)) } >DCCM
-  PROVIDE (__init_array_end = .);
-  PROVIDE (__fini_array_start = .);
-  .fini_array     : { KEEP(*(.fini_array)) } >DCCM
-  PROVIDE (__fini_array_end = .);
+  .preinit_array :
+  {
+    PROVIDE_HIDDEN (__preinit_array_start = .);
+    KEEP (*(.preinit_array))
+    PROVIDE_HIDDEN (__preinit_array_end = .);
+  } > DCCM
+
+  .init_array :
+  {
+    PROVIDE_HIDDEN (__init_array_start = .);
+    KEEP (*(SORT_BY_INIT_PRIORITY(.init_array.*) SORT_BY_INIT_PRIORITY(.ctors.*)))
+    KEEP (*(.init_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .ctors))
+    PROVIDE_HIDDEN (__init_array_end = .);
+  } > DCCM
+
+  .fini_array :
+  {
+    PROVIDE_HIDDEN (__fini_array_start = .);
+    KEEP (*(SORT_BY_INIT_PRIORITY(.fini_array.*) SORT_BY_INIT_PRIORITY(.dtors.*)))
+    KEEP (*(.fini_array EXCLUDE_FILE (*crtbegin.o *crtbegin?.o *crtend.o *crtend?.o ) .dtors))
+    PROVIDE_HIDDEN (__fini_array_end = .);
+  } > DCCM
 
   /* bss segment */
   __bss_start = .;

--- a/libgloss/riscv/sys_utime.c
+++ b/libgloss/riscv/sys_utime.c
@@ -1,4 +1,6 @@
 #include <machine/syscall.h>
+#include <sys/types.h>
+#include <utime.h>
 
 /* Stub.  */
 int


### PR DESCRIPTION
If `__preinit_array_start`, `__init_array_start` and `__fini_array_start` symbols are provided outside of section blocks then its value may differ from the actual section's address. It happens because the previos section may end outside of an alignment boundary of the current section.

Thus, it would be reasonable to just use definitions for `.preinit_array`, `.init_array` and `.fini_array` from original RISC-V default linker script.