### PR TITLE
libgloss: arc-v: Enable caches on startup

### DIFF
--- a/libgloss/Makefile.in
+++ b/libgloss/Makefile.in
@@ -407,6 +407,7 @@ multilibtool_PROGRAMS = $(am__EXEEXT_7)
 @CONFIG_RISCV_TRUE@	riscv/arcv.specs \
 @CONFIG_RISCV_TRUE@	riscv/arcv-crt0.o \
 @CONFIG_RISCV_TRUE@	riscv/arcv.ld \
+@CONFIG_RISCV_TRUE@	riscv/arcv.o \
 @CONFIG_RISCV_TRUE@	riscv/crt0.o
 
 @CONFIG_RISCV_TRUE@am__append_102 = riscv/libgloss.a riscv/libsim.a \

--- a/libgloss/riscv/Makefile.inc
+++ b/libgloss/riscv/Makefile.inc
@@ -5,6 +5,7 @@ multilibtool_DATA += \
 	%D%/arcv.specs \
 	%D%/arcv-crt0.o \
 	%D%/arcv.ld \
+	%D%/arcv.o \
 	%D%/crt0.o
 
 multilibtool_LIBRARIES += %D%/libgloss.a

--- a/libgloss/riscv/arcv-crt0.S
+++ b/libgloss/riscv/arcv-crt0.S
@@ -72,6 +72,11 @@ _start:
 #endif
 	call    __libc_init_array       # Run global initialization functions
 
+#if defined (__riscv_zicsr)
+	# ARC-V specific initialization
+	call    _arcv_cache_enable       # Enable caches
+#endif
+
 	# Get arguments from custom symbols if they are defined. Otherwise,
 	# get them from the stack.
 	.weak _argc

--- a/libgloss/riscv/arcv.c
+++ b/libgloss/riscv/arcv.c
@@ -1,0 +1,44 @@
+/*
+   Copyright (c) 2024, Synopsys, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1) Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2) Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+   3) Neither the name of the Synopsys, Inc., nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#include "arcv.h"
+
+void _arcv_cache_enable ()
+{
+#if defined (__riscv_zicsr)
+  unsigned long mcache = _arcv_csr_read(CSR_NUM_ARCV_MCACHE_CTRL);
+  mcache |=
+    (1 << ARCV_MCACHE_CTRL_IC_EN_OFFSET) |
+    (1 << ARCV_MCACHE_CTRL_DC_EN_OFFSET) |
+    (1 << ARCV_MCACHE_CTRL_DC_L0_EN_OFFSET) |
+    (1 << ARCV_MCACHE_CTRL_L2_EN_OFFSET);
+  _arcv_csr_write(CSR_NUM_ARCV_MCACHE_CTRL, mcache);
+#endif
+}

--- a/libgloss/riscv/arcv.h
+++ b/libgloss/riscv/arcv.h
@@ -1,0 +1,56 @@
+/*
+   Copyright (c) 2024, Synopsys, Inc. All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions are met:
+
+   1) Redistributions of source code must retain the above copyright notice,
+   this list of conditions and the following disclaimer.
+
+   2) Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+   3) Neither the name of the Synopsys, Inc., nor the names of its contributors
+   may be used to endorse or promote products derived from this software
+   without specific prior written permission.
+
+   THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+   AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+   IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+   ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+   LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+   CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+   SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+   INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+   CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+   ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+   POSSIBILITY OF SUCH DAMAGE.
+*/
+
+#ifndef _ARCV_H
+#define _ARCV_H
+
+#define CSR_NUM_ARCV_MCACHE_CTRL            0x7C8
+#define ARCV_MCACHE_CTRL_IC_EN_OFFSET       0x0
+#define ARCV_MCACHE_CTRL_DC_EN_OFFSET       0x8
+#define ARCV_MCACHE_CTRL_DC_L0_EN_OFFSET    0xC
+#define ARCV_MCACHE_CTRL_L2_EN_OFFSET       0x10
+
+inline unsigned long __attribute__((always_inline))
+_arcv_csr_read (int csr_num)
+{
+  unsigned long result;
+  __asm__ __volatile__("csrr %0, %1" : "=r"((result)) : "i"((csr_num)));
+  return result;
+}
+
+inline void __attribute__((always_inline))
+_arcv_csr_write (int csr_num, unsigned long data)
+{
+  __asm__ __volatile__("csrw %0, %1" :: "i"(csr_num), "r"(data));
+}
+
+void _arcv_cache_enable ();
+
+#endif

--- a/libgloss/riscv/arcv.specs
+++ b/libgloss/riscv/arcv.specs
@@ -1,2 +1,2 @@
 *startfile:
-arcv-crt0%O%s crtbegin%O%s
+arcv-crt0%O%s crtbegin%O%s arcv%O%s


### PR DESCRIPTION
To get the best runtime performance it is necessary to enable instruction and data caches, can be disabled out of reset (for the instruction cache it is a configurable behavior, data caches though are always disabled by default according to the ARC-V processors specification).

Note that to enable ARC-V features it's necessary to build GCC multilib configurations with zicsr extension.