### PR TITLE
libgloss: arc: Add _getentropy stub

### DIFF
--- a/libgloss/arc/hl-stub.c
+++ b/libgloss/arc/hl-stub.c
@@ -93,3 +93,10 @@ _link (const char *oldpath __attribute__ ((unused)),
   errno = ENOSYS;
   return -1;
 }
+
+int
+_getentropy (void *buf, size_t buflen)
+{
+  errno = ENOSYS;
+  return -1;
+}

--- a/libgloss/arc/nsim-syscalls.c
+++ b/libgloss/arc/nsim-syscalls.c
@@ -216,6 +216,13 @@ _fstat (int fd, struct stat *buf)
   return __res;
 }
 
+int
+_getentropy (void *buf, size_t buflen)
+{
+  errno = ENOSYS;
+  return -1;
+}
+
 /* Some system calls are implemented in nSIM hostlink, but are available only
    on Linux hosts.  To minimize potential compatibility issues they are by
    default disabled in libgloss build.  */

--- a/libgloss/arc/uart-8250-stub.c
+++ b/libgloss/arc/uart-8250-stub.c
@@ -114,3 +114,10 @@ _argv (int a __attribute__ ((unused)), char *arg __attribute__ ((unused)))
 {
   return -1;
 }
+
+int
+_getentropy (void *buf, size_t buflen)
+{
+  errno = ENOSYS;
+  return -1;
+}


### PR DESCRIPTION
Stub function for _getentropy is presented in libnosys and it is not presented in libgloss libraries for ARC. When libstdc++ is built it detects that _getentropy is presented in the default libgloss library (libnosys). However, then GCC fails to link applications with another libgloss libraries like nSIM, HostLink, boards, etc. because of missing _getentropy stub in corresponding libraries.

Here is an example:

    $ cat getentropy.cpp
    #include <unistd.h>

    int main () {
        unsigned i;                                                                                                                                                          ::getentropy(&i, sizeof(i));
        return 0;
    }

    $ arc64-elf-g++ -mcpu=hs6x -specs=nsim.specs getentropy.cpp
    ...
    ... undefined reference to `_getentropy'
    collect2: error: ld returned 1 exit status

Thus, it is necessary to add _getentropy stub to all ARC libgloss libraries to prevent errors while building even simple C++ programs.

This PR fixes https://github.com/foss-for-synopsys-dwc-arc-processors/toolchain/issues/649.