### PR TITLE
libc: riscv: Use rev8 instruction in strcmp

### DIFF
--- a/newlib/libc/machine/riscv/strcmp.S
+++ b/newlib/libc/machine/riscv/strcmp.S
@@ -99,6 +99,14 @@ strcmp:
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
 
+#ifdef __riscv_zbb
+  rev8  a2, a2
+  rev8  a3, a3
+  sltu  a0, a2, a3
+  neg   a0, a0
+  ori   a0, a0, 1
+  ret
+#else
 #if __riscv_xlen == 64
   sll   a4, a2, 48
   sll   a5, a3, 48
@@ -130,6 +138,7 @@ strcmp:
   and   a5, a5, 0xff
   sub   a0, a4, a5
   ret
+#endif
 
 #else
 


### PR DESCRIPTION
If zbb extension is presented, then rev8 instruction may be used to reverse a word.

I am not sure whether it is necessary to change a big-endian part in the same way. I may be wrong, but it seems like the whole big-endian word reversing part may be replaced by a couple of lines even without `zbb` since in this case words are already reversed.