### PR TITLE
libc: risc-v: Do not check alignment in strcmp in some cases

### DIFF
--- a/newlib/libc/machine/riscv/strcmp.S
+++ b/newlib/libc/machine/riscv/strcmp.S
@@ -30,10 +30,15 @@ strcmp:
 
 .size	strcmp, .-strcmp
 #else
-  or    a4, a0, a1
   li    t2, -1
+
+  # do not waste time on checking an alignment if a target
+  # supports fast misaligned access
+#ifndef __riscv_misaligned_fast
+  or    a4, a0, a1
   and   a4, a4, SZREG-1
   bnez  a4, .Lmisaligned
+#endif
 
 #ifndef __riscv_zbb
 #if SZREG == 4


### PR DESCRIPTION
If target supports fast misaligned memory access then __riscv_misaligned_fast macro is defined. If it's defined then skip checking of alignment in the beginning of strcmp to save 3 extra instructions.

Note that all `-mtune` values for ARC-V targets defined misaligned memory access as fast. All RHX targets support misaligned access by default, and it may be disabled/enabled in RMX (however, it's enabled in the base template). Anyway, GCC assumes that all ARC-V targets support fast misaligned access.

If a customer works with a target that does not support misaligned access, then he could be advised to rebuild the toolchain with `-mstrict-align` options passed explicitly - this option will overwrite `-mtune`'s alignment flags.