### PR TITLE
libgloss: arcv: Move data sections to 0x40000000 by default

### DIFF
--- a/libgloss/riscv/arcv.ld
+++ b/libgloss/riscv/arcv.ld
@@ -18,7 +18,7 @@ ENTRY(_start)
 
 MEMORY {
   ICCM (rx) : ORIGIN = DEFINED (txtmem_addr) ? txtmem_addr : 0x0, LENGTH = DEFINED (txtmem_len) ? txtmem_len : 128K
-  DCCM (rwx) : ORIGIN = DEFINED (datamem_addr) ? datamem_addr :0x80000000, LENGTH = DEFINED (datamem_len) ? datamem_len : 128K
+  DCCM (rwx) : ORIGIN = DEFINED (datamem_addr) ? datamem_addr :0x40000000, LENGTH = DEFINED (datamem_len) ? datamem_len : 128K
 }
 
 SECTIONS


### PR DESCRIPTION
If data sections are stored in `0x40000000` instead of `0x80000000` then the same default linker script may be use both for RV32 and RV64 binaries.