### PR TITLE
libm: Add CMPLX, CMPLXF and CMPLXL macros

### DIFF
--- a/newlib/libc/include/complex.h
+++ b/newlib/libc/include/complex.h
@@ -137,6 +137,18 @@ double creal(double complex);
 float crealf(float complex);
 long double creall(long double complex);
 
+#if __ISO_C_VISIBLE >= 2011
+#ifdef _HAVE_BUILTIN_COMPLEX
+#define CMPLX(r,i) __builtin_complex((double)(r), (double)(i))
+#define CMPLXF(r,i) __builtin_complex((float)(r), (float)(i))
+#define CMPLXL(r,i) __builtin_complex((long double)(r), (long double)(i))
+#else
+#define CMPLX(r,i) ((double complex) ((double) (r) + (double complex) I * (double) (i)))
+#define CMPLXF(r,i) ((float complex) ((float) (r) + (float complex) I * (float) (i)))
+#define CMPLXL(r,i) ((long double complex) ((long double) (r) + (long double complex) I * (long double) (i)))
+#endif
+#endif
+
 #if __GNU_VISIBLE
 double complex clog10(double complex);
 float complex clog10f(float complex);


### PR DESCRIPTION
This is a backport of the same patch from Picolibc repository with all fixes:

https://github.com/picolibc/picolibc/commit/197657202913

    libm: Add CMPLX, CMPLXF and CMPLXL macros

    These use __builtin_complex if available, otherwise they open
    code as suggested by the C standard.

    Signed-off-by: Keith Packard <keithp@keithp.com>

https://github.com/picolibc/picolibc/commit/a00c65d42760

    complex.h: Add type casting to CMPLX, CMPLXF and CMPLXL macros

    Adding type casting to CMPLX, CMPLXF and CMPLXL macros to
    ensure type safety constructing complex numbers using
    __builtin_complex function. The real and imaginary parts
    passed to __builtin_complex function are explicity cast to
    double, float and long double respectively, to match the
    types expected by the function.

    This change improves code clarity and prevents unintended
    type conversions when using macros to construct complex
    numbers.

    Signed-off-by: Mostafa Salman <mostafas@synopsys.com>