### PR TITLE
libgloss: arcv: Initialize mstatus.VS if misa.V is presented

### DIFF
--- a/libgloss/riscv/arcv-crt0.S
+++ b/libgloss/riscv/arcv-crt0.S
@@ -50,6 +50,22 @@ _start:
 	csrwi   fcsr, 0
 #endif
 
+	# Set mstatus.VS if misa.V is set.
+#ifdef __riscv_zicsr
+	# Check misa.V (misa[21]) for V extension presence.
+	csrr t0, misa
+	srli t0, t0, 21
+	andi t0, t0, 1
+	beqz t0, 1f
+
+	# Set mstatus.VS (mstatus[10:9]) if V extension is present.
+	csrr t0, mstatus
+	li t1, 1536
+	or t0, t1, t0
+	csrw mstatus, t0
+#endif
+
+1:
 	# Clear the bss segment
 	la      a0, __bss_start
 	la      a2, _end


### PR DESCRIPTION
According to RISC-V specification:

    Attempts to execute any vector instruction, or to access the
    vector CSRs, raise an illegal-instruction exception when
    mstatus.VS is set to Off.

Presence of V extension may be checked by reading `misa.V` (`misa[21`]) bit. If that bit is set, then 0x3 must be set in `mstatus.VS` (`mstatus[10:9]`) field.