### PR TITLE
Check ARC-V build CSR for setting mstatus.V + a small patch

### DIFF
--- a/libgloss/riscv/arcv-crt0.S
+++ b/libgloss/riscv/arcv-crt0.S
@@ -92,8 +92,10 @@ _start:
 #endif
 	call    __libc_init_array       # Run global initialization functions
 
+#ifndef CRT0_NO_CSR
 	# ARC-V specific initialization
 	call    _arcv_cache_enable       # Enable caches
+#endif
 
 	# Get arguments from custom symbols if they are defined. Otherwise,
 	# get them from the stack.

--- a/libgloss/riscv/arcv-crt0.S
+++ b/libgloss/riscv/arcv-crt0.S
@@ -50,25 +50,6 @@ _start:
 	csrwi   fcsr, 0
 #endif
 
-#ifndef CRT0_NO_CSR
-	# Set mstatus.VS if misa.V is set.
-.option push
-.option norelax
-.option arch, +zicsr
-	# Check misa.V (misa[21]) for V extension presence.
-	csrr    t0, misa
-	srli    t0, t0, 21
-	andi    t0, t0, 1
-	beqz    t0, 1f
-
-	# Set mstatus.VS (mstatus[10:9]) if V extension is present.
-	csrr    t0, mstatus
-	li      t1, 512
-	or      t0, t1, t0
-	csrw    mstatus, t0
-.option pop
-#endif
-
 1:
 	# Clear the bss segment
 	la      a0, __bss_start
@@ -95,6 +76,7 @@ _start:
 #ifndef CRT0_NO_CSR
 	# ARC-V specific initialization
 	call    _arcv_cache_enable       # Enable caches
+	call    _arcv_vector_enable      # Set mstatus.VS
 #endif
 
 	# Get arguments from custom symbols if they are defined. Otherwise,

--- a/libgloss/riscv/arcv.c
+++ b/libgloss/riscv/arcv.c
@@ -41,3 +41,18 @@ _arcv_cache_enable ()
     (1 << ARCV_MCACHE_CTRL_L2_EN_OFFSET);
   _arcv_csr_write(CSR_NUM_ARCV_MCACHE_CTRL, mcache);
 }
+
+void __attribute__((target("arch=+zicsr")))
+_arcv_vector_enable ()
+{
+  unsigned long rvv_build = _arcv_csr_read(CSR_NUM_ARCV_RVV_BUILD);
+  unsigned long v_option = (rvv_build >> ARCV_RVV_BUILD_V_OPTION_OFFSET) &
+    ARCV_RVV_BUILD_V_OPTION_MASK;
+
+  if (v_option != 0)
+    {
+      unsigned long mstatus = _arcv_csr_read(CSR_NUM_MSTATUS);
+      mstatus |= (1 << MSTATUS_VS_OFFSET);
+      _arcv_csr_write(CSR_NUM_MSTATUS, mstatus);
+    }
+}

--- a/libgloss/riscv/arcv.h
+++ b/libgloss/riscv/arcv.h
@@ -31,11 +31,19 @@
 #ifndef _ARCV_H
 #define _ARCV_H
 
+#define CSR_NUM_MSTATUS                     0x300
+#define MSTATUS_VS_OFFSET                   0x9
+#define MSTATUS_VS_MASK                     0x3
+
 #define CSR_NUM_ARCV_MCACHE_CTRL            0x7C8
 #define ARCV_MCACHE_CTRL_IC_EN_OFFSET       0x0
 #define ARCV_MCACHE_CTRL_DC_EN_OFFSET       0x8
 #define ARCV_MCACHE_CTRL_DC_L0_EN_OFFSET    0xC
 #define ARCV_MCACHE_CTRL_L2_EN_OFFSET       0x10
+
+#define CSR_NUM_ARCV_RVV_BUILD              0xFC4
+#define ARCV_RVV_BUILD_V_OPTION_OFFSET      0x0
+#define ARCV_RVV_BUILD_V_OPTION_MASK        0x7
 
 inline unsigned long __attribute__((always_inline,target("arch=+zicsr")))
 _arcv_csr_read (int csr_num)
@@ -52,5 +60,6 @@ _arcv_csr_write (int csr_num, unsigned long data)
 }
 
 void _arcv_cache_enable ();
+void _arcv_vector_enable ();
 
 #endif


### PR DESCRIPTION
# Check ARC-V build CSR for setting mstatus.V 

`misa.V` bit is set only when full V extension is presented. However, if a target implements only a subset of V then this bit is not set and we cannot rely on it for determining whether we need to set `mstatus.VS` bits.

To overcome this limitation we can use ARC-V build register for RVV features. If its first 3 bits are not 0, then vector extensions are presented.

# Do not enable caches if CSRs are disabled

Just a small fix to eliminated using CSR when they are disabled (`--crt0=no-csr` is passed).