### PR TITLE
fixup! libgloss: arcv: Force using zicsr for crt0 by default

### DIFF
--- a/libgloss/Makefile.in
+++ b/libgloss/Makefile.in
@@ -10472,7 +10472,7 @@ maintainer-clean-local: maintainer-clean-multi
 @CONFIG_MCORE_TRUE@@MCORE_BUILD_PE_TRUE@mcore/cmb.specs: mcore/pe-cmb.specs
 @CONFIG_MCORE_TRUE@@MCORE_BUILD_PE_TRUE@	$(AM_V_GEN)cp $< $@
 
-@CONFIG_RISCV_TRUE@riscv/arcv-crt0-no-csr.$(OBJEXT): riscv/crt0.S
+@CONFIG_RISCV_TRUE@riscv/arcv-crt0-no-csr.$(OBJEXT): riscv/arcv-crt0.S
 @CONFIG_RISCV_TRUE@	$(AM_V_CPPAS)$(CPPASCOMPILE) -DCRT0_NO_CSR -o $@ -c $<
 @CONFIG_SPARC_TRUE@@SPARC_BUILD_CYGMON_TRUE@sparc/cygmon.ld: $(srcdir)/sparc/@SPARC_CYGMONLDSCRIPTTEMPL@ sparc/Makefile.inc
 @CONFIG_SPARC_TRUE@@SPARC_BUILD_CYGMON_TRUE@	$(AM_V_GEN)sed 's/TARGET_OBJ_FORMAT/$(sparc_$(SPARC_CPU)_OBJ_FORMAT)/g;s/TARGET_RAM_START/$(sparc_$(SPARC_CPU)_RAM_START)/g;' < $< > $@

--- a/libgloss/riscv/Makefile.inc
+++ b/libgloss/riscv/Makefile.inc
@@ -9,7 +9,7 @@ multilibtool_DATA += \
 	%D%/arcv.o \
 	%D%/crt0.o
 
-%D%/arcv-crt0-no-csr.$(OBJEXT): %D%/crt0.S
+%D%/arcv-crt0-no-csr.$(OBJEXT): %D%/arcv-crt0.S
 	$(AM_V_CPPAS)$(CPPASCOMPILE) -DCRT0_NO_CSR -o $@ -c $<
 
 multilibtool_LIBRARIES += %D%/libgloss.a


### PR DESCRIPTION
arcv-crt0.S must be used instead of crt0.S for ARC-V targets.