### PR TITLE
fixup! arc: libc: Add support of 16-entry register file

### DIFF
--- a/newlib/libc/machine/arc/strchr.S
+++ b/newlib/libc/machine/arc/strchr.S
@@ -31,7 +31,8 @@
 /* This implementation is optimized for performance.  For code size a generic
    implementation of this function from newlib/libc/string/strchr.c will be
    used.  */
-#if !defined (__OPTIMIZE_SIZE__) && !defined (PREFER_SIZE_OVER_SPEED)
+#if !defined (__OPTIMIZE_SIZE__) && !defined (PREFER_SIZE_OVER_SPEED) \
+    && !defined (__ARC_RF16__)
 
 #include "asm.h"
 


### PR DESCRIPTION
Disable building of `strchr.S` for `em_mini` with `-mrf16`. It's necessary because gas for ARC Classic does not support `-mrf16` and fallback implementations must be used.